### PR TITLE
Rename deploy variables for clarity and add folder permission docs

### DIFF
--- a/mlops/genie-migration/README.md
+++ b/mlops/genie-migration/README.md
@@ -43,7 +43,7 @@ As of December 2025, Databricks Asset Bundles don't natively support Genie Space
 ├─────────────────────────────────────────────────────────────────────────────┤
 │  8. databricks bundle validate --target prod                                │
 │  9. databricks bundle deploy --target prod \                                │
-│       --var genie_config=/Workspace/Shared/.bundle/.../genie_spaces/x.json  │
+│       --var deploy_config_path=/Workspace/Shared/.bundle/.../genie_spaces/x.json│
 │     → Syncs files + sets job parameters                                     │
 │ 10. databricks bundle run deploy_genie_space --target prod                  │
 │     → Creates/updates Genie Space from synced JSON                          │
@@ -62,7 +62,7 @@ Key settings:
 
 ```yaml
 variables:
-  warehouse_id:
+  target_warehouse_id:
     default: "<your-warehouse-id>"
 
   run_as_service_principal:
@@ -94,6 +94,7 @@ Supports both **Databricks managed SPs** and **Microsoft Entra ID SPs**. See [do
 4. **Grant SP permissions**:
    - Source: CAN EDIT on Genie Space (required for export)
    - Target: CAN USE on SQL Warehouse (required for deploy)
+   - Target: CAN MANAGE on `target_parent_path` folder (required to create Genie Spaces)
 
 ## Command Reference
 
@@ -125,15 +126,15 @@ git push
 # NOTE: --var must be on deploy, not run (base_parameters are set at deploy time)
 databricks bundle validate --target prod
 databricks bundle deploy --target prod \
-    --var genie_config=/Workspace/Shared/.bundle/genie-migration/prod/files/genie_spaces/<filename>.json
+    --var deploy_config_path=/Workspace/Shared/.bundle/genie-migration/prod/files/genie_spaces/<filename>.json
 
 # Run deploy job (first time - creates new space)
 databricks bundle run deploy_genie_space --target prod
 
 # Run deploy job (subsequent - updates existing space)
 databricks bundle deploy --target prod \
-    --var genie_config=/Workspace/Shared/.bundle/genie-migration/prod/files/genie_spaces/<filename>.json \
-    --var space_id=<existing-space-id>
+    --var deploy_config_path=/Workspace/Shared/.bundle/genie-migration/prod/files/genie_spaces/<filename>.json \
+    --var target_space_id=<existing-space-id>
 databricks bundle run deploy_genie_space --target prod
 ```
 
@@ -166,10 +167,10 @@ This field is portable and passed directly to `create_space()` or `update_space(
 
 ### Deployment Behavior
 
-| Scenario                   | Behavior                         |
-|----------------------------|----------------------------------|
-| No `--var space_id`        | Creates new space, outputs new ID |
-| With `--var space_id=<id>` | Updates existing space           |
+| Scenario                          | Behavior                         |
+|-----------------------------------|----------------------------------|
+| No `--var target_space_id`        | Creates new space, outputs new ID |
+| With `--var target_space_id=<id>` | Updates existing space           |
 
 **Note:** Target workspace gets a **different space_id** than source. Save the new ID for subsequent deployments.
 

--- a/mlops/genie-migration/databricks.yml.template
+++ b/mlops/genie-migration/databricks.yml.template
@@ -8,24 +8,24 @@ bundle:
   name: genie-migration
 
 variables:
-  # TODO: SQL Warehouse ID for Genie Space in target workspace
-  warehouse_id:
-    description: "SQL Warehouse ID for Genie Space"
+  # TODO: SQL Warehouse ID in target workspace
+  target_warehouse_id:
+    description: "SQL Warehouse ID in target workspace"
     default: ""
 
-  # TODO: Workspace path where Genie Space will be created
-  genie_parent_path:
-    description: "Workspace path for Genie Space"
+  # TODO: Workspace path where new Genie Spaces will be created
+  target_parent_path:
+    description: "Workspace path for new Genie Spaces"
     default: "/Shared/genie_spaces"
 
   # Genie Space config file to deploy (must be provided via --var)
-  genie_config:
+  deploy_config_path:
     description: "Path to Genie Space JSON config file"
     default: ""
 
-  # Space ID for idempotent updates (set after first deploy)
-  space_id:
-    description: "Existing Genie Space ID to update"
+  # Target Space ID for idempotent updates (set after first deploy)
+  target_space_id:
+    description: "Existing Genie Space ID to update (optional)"
     default: ""
 
   # TODO: Source space ID for export operations
@@ -70,10 +70,10 @@ resources:
           notebook_task:
             notebook_path: scripts/deploy_genie_space.py
             base_parameters:
-              config_path: ${var.genie_config}
-              warehouse_id: ${var.warehouse_id}
-              parent_path: ${var.genie_parent_path}
-              space_id: ${var.space_id}
+              config_path: ${var.deploy_config_path}
+              target_warehouse_id: ${var.target_warehouse_id}
+              target_parent_path: ${var.target_parent_path}
+              target_space_id: ${var.target_space_id}
       timeout_seconds: 600
       max_concurrent_runs: 1
 

--- a/mlops/genie-migration/docs/SETUP_GUIDE.md
+++ b/mlops/genie-migration/docs/SETUP_GUIDE.md
@@ -92,7 +92,8 @@ You now have:
 4. **Grant yourself "User" role on the SP**: Click on the SP → **Permissions** → **Grant access** → Add yourself with **User** role
    > This is required to create jobs with `run_as` that reference this SP
 5. Go to **SQL Warehouses** → your warehouse → **Permissions** → Add SP with **Can Use**
-6. Create the folder `/Workspace/Shared/genie_spaces` and give SP **Can Manage** permission
+6. **Grant SP access to the target folder**: Navigate to the `target_parent_path` folder (e.g., `/Workspace/Shared/genie_spaces`) → Right-click → **Permissions** → Add SP with **Can Manage**
+   > This is required for the SP to create Genie Spaces in this folder
 
 ---
 
@@ -133,12 +134,12 @@ Run the deploy job via DAB. Since no space_id is provided, it creates a new spac
 # Configure CLI to point to DESTINATION workspace
 databricks configure --host https://dest-workspace.azuredatabricks.net
 
-# Deploy the bundle with genie_config pointing to bundle location
+# Deploy the bundle with deploy_config_path pointing to bundle location
 # NOTE: --var must be on deploy, not run (base_parameters are set at deploy time)
 databricks bundle deploy --target dev \
-    --var genie_config="/Workspace/Shared/.bundle/genie-migration/dev/files/genie_spaces/my_space.json"
+    --var deploy_config_path="/Workspace/Shared/.bundle/genie-migration/dev/files/genie_spaces/my_space.json"
 
-# Run deploy job (creates new space since space_id is empty)
+# Run deploy job (creates new space since target_space_id is empty)
 databricks bundle run deploy_genie_space --target dev
 ```
 
@@ -164,10 +165,10 @@ SPACE_ID=xyz-789-new-dest-space-id
 Now that you have the destination space ID, future deployments will **update** the existing space instead of creating new ones.
 
 ```bash
-# Deploy with both genie_config and space_id
+# Deploy with both deploy_config_path and target_space_id
 databricks bundle deploy --target dev \
-    --var genie_config="/Workspace/Shared/.bundle/genie-migration/dev/files/genie_spaces/my_space.json" \
-    --var space_id="xyz-789-new-dest-space-id"
+    --var deploy_config_path="/Workspace/Shared/.bundle/genie-migration/dev/files/genie_spaces/my_space.json" \
+    --var target_space_id="xyz-789-new-dest-space-id"
 
 databricks bundle run deploy_genie_space --target dev
 ```
@@ -185,6 +186,6 @@ Updated Genie Space: xyz-789-new-dest-space-id
 | ID | Where | When You Use It |
 | ---- | ------- | ----------------- |
 | **Source Space ID** | Source workspace | When running export job with `--var source_space_id` |
-| **Destination Space ID** | Destination workspace | When running deploy job with `--var space_id` (after first deploy) |
+| **Destination Space ID** | Destination workspace | When running deploy job with `--var target_space_id` (after first deploy) |
 
 These are **different IDs** for **different spaces** in **different workspaces**.


### PR DESCRIPTION
## Summary
- Renamed deploy variables for better clarity: `warehouse_id` → `target_warehouse_id`, `genie_parent_path` → `target_parent_path`, `space_id` → `target_space_id`, `genie_config` → `deploy_config_path`
- Added documentation requiring CAN MANAGE permission on `target_parent_path` folder for Service Principal to create Genie Spaces

## Test plan
- [x] Verify `databricks bundle validate` passes with new variable names
- [x] Test export job still works unchanged
- [x] Test deploy job with renamed variables
- [x] Confirm SP with CAN MANAGE on target folder can create Genie Spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)