### PR TITLE
Add security hardening for public release

### DIFF
--- a/mlops/genie-migration/scripts/deploy_genie_space.py
+++ b/mlops/genie-migration/scripts/deploy_genie_space.py
@@ -22,6 +22,7 @@ Parameters (via job or widget):
 """
 
 import json
+import re
 from typing import Optional
 
 from databricks.sdk import WorkspaceClient
@@ -39,6 +40,17 @@ config_path = dbutils.widgets.get("config_path")
 target_warehouse_id = dbutils.widgets.get("target_warehouse_id")
 target_parent_path = dbutils.widgets.get("target_parent_path")
 target_space_id = dbutils.widgets.get("target_space_id") or None  # Convert empty string to None
+
+
+def validate_id(value: str, name: str, pattern: str) -> None:
+    """Validate that an ID matches expected format."""
+    if value and not re.match(pattern, value):
+        raise ValueError(f"Invalid {name} format: {value}")
+
+
+# Validate ID formats to prevent injection
+validate_id(target_space_id, "target_space_id", r"^[a-f0-9]{32}$")
+validate_id(target_warehouse_id, "target_warehouse_id", r"^[a-f0-9]{16}$")
 
 if not config_path:
     raise ValueError("config_path parameter is required")

--- a/mlops/genie-migration/scripts/export_genie_space.py
+++ b/mlops/genie-migration/scripts/export_genie_space.py
@@ -19,6 +19,7 @@ Parameters (via job or widget):
 
 import json
 from datetime import datetime, timezone
+from pathlib import Path
 
 import os
 import re
@@ -97,6 +98,15 @@ def export_genie_space(space_id: str, output_path: str) -> dict:
         final_path = f"{output_path}/{safe_title}.json"
     else:
         final_path = output_path
+
+    # Validate path to prevent directory traversal attacks
+    ALLOWED_PREFIXES = ("/Workspace/Shared/", "/Workspace/Users/")
+    resolved = str(Path(final_path).resolve())
+    if not any(resolved.startswith(prefix) for prefix in ALLOWED_PREFIXES):
+        raise ValueError(
+            f"Output path must be under /Workspace/Shared/ or /Workspace/Users/. "
+            f"Got: {final_path}"
+        )
 
     # Write to workspace file using native file I/O
     # Convert /Workspace path to local filesystem path


### PR DESCRIPTION
## Summary
- Add path traversal protection in export script to prevent writing files outside allowed directories
- Add input validation for space_id and warehouse_id to ensure they match expected hex formats
- Prepares codebase for public release by addressing security review findings

## Test plan
- [x] Verify export script rejects paths outside /Workspace/Shared/ and /Workspace/Users/
- [x] Verify deploy script rejects malformed space_id and warehouse_id values
- [x] Verify normal operations still work with valid inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)