### PR TITLE
Fix Vector Search MCP server URL to use catalog/schema format

### DIFF
--- a/agents/openai-multiagent-mcp/src/agent.py
+++ b/agents/openai-multiagent-mcp/src/agent.py
@@ -53,7 +53,8 @@ SYSTEM_PROMPT = mlflow.genai.load_prompt(
 # Load other resources
 LLM_ENDPOINT_NAME = agent_config.get("llm").get("endpoint_name")
 UC_FUNCTIONS = tools_conifg.get("uc_functions")
-VECTOR_SEARCH_USER_NAME = tools_conifg.get("vector_search").get("user_name")
+VECTOR_SEARCH_CATALOG = tools_conifg.get("vector_search").get("catalog")
+VECTOR_SEARCH_SCHEMA = tools_conifg.get("vector_search").get("schema")
 GENIE_SPACE_ID = tools_conifg.get("genie").get("space_id")
 
 
@@ -71,9 +72,9 @@ if UC_FUNCTIONS:
             )
 
 # Add vector search MCP server
-if VECTOR_SEARCH_USER_NAME:
+if VECTOR_SEARCH_CATALOG and VECTOR_SEARCH_SCHEMA:
     MANAGED_MCP_SERVER_URLS.append(
-        f"{host}/api/2.0/mcp/vector-search/users/{VECTOR_SEARCH_USER_NAME}"
+        f"{host}/api/2.0/mcp/vector-search/{VECTOR_SEARCH_CATALOG}/{VECTOR_SEARCH_SCHEMA}"
     )
 
 # Add Genie MCP server

--- a/agents/openai-multiagent-mcp/src/config.template.yaml
+++ b/agents/openai-multiagent-mcp/src/config.template.yaml
@@ -27,7 +27,8 @@ agent:
         function_name: users.first_last.search_web
     uc_connection: your_uc_connection_for_web_search_api
     vector_search:
-      user_name: your_user_name
+      catalog: your_catalog
+      schema: your_schema
       endpoint_name: your_vs_endpoint_name
       index_name: your_vs_index_name
     genie:


### PR DESCRIPTION
## Summary
- Fixed Vector Search MCP server endpoint URL to use the correct format `/api/2.0/mcp/vector-search/{catalog}/{schema}` per official Databricks documentation
- Updated config template and agent.py to use `catalog` and `schema` parameters instead of `user_name`
- Previous implementation only worked coincidentally when catalog was literally "users"

## Test plan
- [x] Deploy with `databricks bundle deploy`
- [x] Verify Vector Search tools load correctly
- [x] Test a query that uses Vector Search to confirm the endpoint works

🤖 Generated with [Claude Code](https://claude.com/claude-code)