### PR TITLE
Switch pipeline jobs from classic clusters to serverless compute

### DIFF
--- a/agents/openai-retrieval-agent-dabs/resources/01_full_pipeline.job.yml
+++ b/agents/openai-retrieval-agent-dabs/resources/01_full_pipeline.job.yml
@@ -22,7 +22,6 @@ resources:
               catalog: "{{job.parameters.catalog}}"
               schema: "{{job.parameters.schema}}"
           timeout_seconds: 3600
-          job_cluster_key: processing_cluster
 
         - task_key: create_vector_index
           description: "Create and sync Vector Search index from parsed documents"
@@ -35,7 +34,6 @@ resources:
               schema: "{{job.parameters.schema}}"
               mode: "create"
           timeout_seconds: 3600
-          job_cluster_key: processing_cluster
 
         - task_key: deploy_agent
           description: "Log, register, and deploy retrieval agent to Model Serving"
@@ -48,15 +46,3 @@ resources:
               schema: "{{job.parameters.schema}}"
               mlflow_experiment: ${var.experiment_name}
           timeout_seconds: 1800
-          job_cluster_key: processing_cluster
-
-      job_clusters:
-        - job_cluster_key: processing_cluster
-          new_cluster:
-            spark_version: "15.4.x-scala2.12"
-            node_type_id: "Standard_DS4_v2"
-            autoscale:
-              min_workers: 1
-              max_workers: 4
-            spark_conf:
-              spark.databricks.cluster.profile: singleNode

--- a/agents/openai-retrieval-agent-dabs/resources/02_index_update.job.yml
+++ b/agents/openai-retrieval-agent-dabs/resources/02_index_update.job.yml
@@ -22,7 +22,6 @@ resources:
               catalog: "{{job.parameters.catalog}}"
               schema: "{{job.parameters.schema}}"
           timeout_seconds: 3600
-          job_cluster_key: processing_cluster
 
         - task_key: sync_vector_index
           description: "Sync Vector Search index with updated documents"
@@ -35,11 +34,3 @@ resources:
               schema: "{{job.parameters.schema}}"
               mode: "sync_only"
           timeout_seconds: 1800
-          job_cluster_key: processing_cluster
-
-      job_clusters:
-        - job_cluster_key: processing_cluster
-          new_cluster:
-            spark_version: "15.4.x-scala2.12"
-            node_type_id: "Standard_DS4_v2"
-            num_workers: 1

--- a/agents/openai-retrieval-agent-dabs/resources/03_agent_deploy.job.yml
+++ b/agents/openai-retrieval-agent-dabs/resources/03_agent_deploy.job.yml
@@ -25,14 +25,3 @@ resources:
               schema: "{{job.parameters.schema}}"
               mlflow_experiment: "{{job.parameters.mlflow_experiment}}"
           timeout_seconds: 1800
-          job_cluster_key: deploy_cluster
-
-      job_clusters:
-        - job_cluster_key: deploy_cluster
-          new_cluster:
-            spark_version: "15.4.x-scala2.12"
-            node_type_id: "Standard_DS3_v2"
-            num_workers: 0
-            spark_conf:
-              spark.master: "local[*, 4]"
-              spark.databricks.cluster.profile: singleNode

--- a/agents/openai-retrieval-agent-dabs/resources/04_evaluation.job.yml
+++ b/agents/openai-retrieval-agent-dabs/resources/04_evaluation.job.yml
@@ -25,14 +25,3 @@ resources:
               schema: "{{job.parameters.schema}}"
               mlflow_experiment: "{{job.parameters.mlflow_experiment}}"
           timeout_seconds: 3600
-          job_cluster_key: eval_cluster
-
-      job_clusters:
-        - job_cluster_key: eval_cluster
-          new_cluster:
-            spark_version: "15.4.x-scala2.12"
-            node_type_id: "Standard_DS3_v2"
-            num_workers: 0
-            spark_conf:
-              spark.master: "local[*, 4]"
-              spark.databricks.cluster.profile: singleNode


### PR DESCRIPTION
## Summary
- Remove `job_cluster_key` references from all pipeline job tasks
- Remove `job_clusters` definitions from all four pipeline configurations
- Tasks will now run on serverless compute by default

## Test plan
- [x] Deploy bundle to dev target and verify jobs are configured for serverless
- [x] Run full pipeline job and verify tasks execute successfully on serverless compute

🤖 Generated with [Claude Code](https://claude.com/claude-code)