### PR TITLE
Enable Change Data Feed on source table for Vector Search index

### DIFF
--- a/agents/openai-retrieval-agent-dabs/src/02_create_vector_index.py
+++ b/agents/openai-retrieval-agent-dabs/src/02_create_vector_index.py
@@ -114,6 +114,17 @@ wait_for_endpoint_ready(VS_ENDPOINT)
 # COMMAND ----------
 
 # MAGIC %md
+# MAGIC ## Enable Change Data Feed on Source Table
+
+# COMMAND ----------
+
+# Delta Sync indexes require Change Data Feed (CDF) to be enabled on the source table
+spark.sql(f"ALTER TABLE {CHUNKS_TABLE} SET TBLPROPERTIES (delta.enableChangeDataFeed = true)")
+print(f"Change Data Feed enabled on {CHUNKS_TABLE}")
+
+# COMMAND ----------
+
+# MAGIC %md
 # MAGIC ## Create or Sync Delta Sync Index
 
 # COMMAND ----------


### PR DESCRIPTION
## Summary
- Added step to enable Change Data Feed (CDF) on the source Delta table before creating the Vector Search index
- Delta Sync indexes require CDF to track changes in the source table
- The ALTER TABLE command is idempotent, safe to run multiple times

## Test plan
- [x] Run the 02_create_vector_index.py notebook on Databricks
- [x] Verify the Vector Search index is created successfully without CDF errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)