### PR TITLE
Add databricks.template.yml and simplify MLflow experiment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All materials are provided AS IS, without any guarantees or warranties, and are 
 * Multi-Agent Genie with OpenAI Response API
 * Multi-Agent Knowledge Assistant with OpenAI Response API
 * Tool-Calling Agent with Databricks Managed MCPs
-* Agent Deployement with Databricks Asset Bundles
+* Agent Deployment with Databricks Asset Bundles
 * Text2SQL Agent with Databricks UC Managed MCP
 * Text2SQL Agent with LangChain
 * Async Agentic Task with Lakeflow Jobs

--- a/agents/openai-retrieval-agent-dabs/README.md
+++ b/agents/openai-retrieval-agent-dabs/README.md
@@ -15,10 +15,10 @@ This example demonstrates an end-to-end retrieval agent pipeline:
 ## Architecture
 
 ```text
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                          ORCHESTRATION LAYER                                │
-│                     (DABs + Lakeflow Jobs Pipeline)                         │
-└─────────────────────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────────┐
+│                          ORCHESTRATION LAYER                           │
+│                     (DABs + Lakeflow Jobs Pipeline)                    │
+└────────────────────────────────────────────────────────────────────────┘
                                     │
         ┌───────────────────────────┼───────────────────────────┐
         ▼                           ▼                           ▼
@@ -46,7 +46,7 @@ This example demonstrates an end-to-end retrieval agent pipeline:
 ```text
 agents/openai-retrieval-agent-dabs/
 ├── README.md                           # This file
-├── databricks.yml                      # DABs config + infrastructure variables
+├── databricks.template.yml             # DABs config template (copy to databricks.yml)
 ├── requirements.txt                    # Python dependencies
 ├── src/
 │   ├── configs.template.yaml           # Agent runtime config template (LLM settings)
@@ -85,11 +85,12 @@ agents/openai-retrieval-agent-dabs/
 Infrastructure settings are defined as DAB variables in `databricks.yml`:
 
 | Variable | Description | Default |
-|----------|-------------|---------|
+| ---------- | ------------- | --------- |
 | `catalog` | Unity Catalog name | `main` |
 | `schema` | Schema name | `default` |
-| `experiment_name` | MLflow experiment path | `/Users/{user}/retrieval-agent-mcp` |
 | `vs_endpoint` | Vector Search endpoint name | `retrieval-agent-vs-endpoint` |
+
+The MLflow experiment is automatically created at `/Users/{user}/experiments/retrieval-agent-mcp` (with a `[dev ...]` prefix in development mode).
 
 Agent runtime settings (LLM config) are in `src/configs.yaml`.
 
@@ -101,13 +102,16 @@ Agent runtime settings (LLM config) are in `src/configs.yaml`.
 cd agents/openai-retrieval-agent-dabs
 ```
 
-### Step 2: Create Agent Config File
+### Step 2: Create Config Files
 
-Copy the template:
+Copy the templates:
 
 ```bash
+cp databricks.template.yml databricks.yml
 cp src/configs.template.yaml src/configs.yaml
 ```
+
+### Step 3: Configure Agent Runtime
 
 Edit `src/configs.yaml` to configure the LLM endpoint:
 
@@ -120,7 +124,7 @@ agent_configs:
     max_tokens: 4096
 ```
 
-### Step 3: Update DABs Configuration
+### Step 4: Configure DABs
 
 Edit `databricks.yml` to set your workspace URL and optionally override variables:
 
@@ -140,7 +144,7 @@ targets:
     #   catalog: dev_catalog
 ```
 
-### Step 4: Upload Your Documents
+### Step 5: Upload Your Documents
 
 Upload PDF documents to `/Volumes/{catalog}/{schema}/user_guides`.
 
@@ -204,7 +208,7 @@ databricks bundle run full_pipeline --var catalog=prod_catalog
 The following paths are automatically derived from the `catalog` and `schema` variables:
 
 | Resource | Path |
-|----------|------|
+| ---------- | ------ |
 | Source Volume | `/Volumes/{catalog}/{schema}/user_guides` |
 | Chunks Table | `{catalog}.{schema}.user_guide_chunks` |
 | Images Volume | `/Volumes/{catalog}/{schema}/parsed_images` |

--- a/agents/openai-retrieval-agent-dabs/databricks.template.yml
+++ b/agents/openai-retrieval-agent-dabs/databricks.template.yml
@@ -1,0 +1,39 @@
+bundle:
+  name: retrieval-agent-mcp
+
+variables:
+  catalog:
+    description: Unity Catalog name
+    default: main
+  schema:
+    description: Schema name
+    default: default
+  vs_endpoint:
+    description: Vector Search endpoint name
+    default: retrieval-agent-vs-endpoint
+
+include:
+  - resources/*.job.yml
+
+resources:
+  experiments:
+    retrieval_agent_experiment:
+      name: /Users/${workspace.current_user.userName}/experiments/retrieval-agent-mcp
+
+targets:
+  dev:
+    mode: development
+    default: true
+    workspace:
+      host: https://YOUR_WORKSPACE.cloud.databricks.com
+    # Optional: override variables for dev
+    # variables:
+    #   catalog: dev_catalog
+
+  prod:
+    mode: production
+    workspace:
+      host: https://YOUR_WORKSPACE.cloud.databricks.com
+    # Optional: override variables for prod
+    # variables:
+    #   catalog: prod_catalog


### PR DESCRIPTION
## Summary

- Add `databricks.template.yml` with generic defaults for users to copy to `databricks.yml`
- Remove the `experiment_name` variable which was confusing (the default value didn't reflect DAB's dev mode prefixing behavior)
- MLflow experiment is now defined directly in the resource declaration, letting DAB handle the naming/prefixing automatically
- Update README setup instructions to include copying both template files

## Test plan

- [x] Verify `databricks bundle validate` passes with the new template
- [x] Deploy to dev mode and confirm experiment is created with `[dev ...]` prefix
- [x] Verify jobs correctly reference the experiment via `${resources.experiments.retrieval_agent_experiment.name}`

🤖 Generated with [Claude Code](https://claude.ai/code)