### PR TITLE
Migrate evaluation to mlflow.genai.evaluate API

### DIFF
--- a/agents/openai-retrieval-agent-dabs/src/03_deployment.py
+++ b/agents/openai-retrieval-agent-dabs/src/03_deployment.py
@@ -231,11 +231,16 @@ try:
         uc_registered_model_info.version,
         tags={"endpointSource": "retrieval-agent-mcp"},
     )
+    AGENT_ENDPOINT_NAME = deployment.endpoint_name
     print(f"Deployment initiated successfully!")
-    print(f"Endpoint will be available at: {UC_MODEL_NAME.replace('.', '_')}")
+    print(f"Endpoint name: {AGENT_ENDPOINT_NAME}")
 except ValueError as e:
     if "currently updating" in str(e):
         print("Endpoint is already updating. Deployment will complete shortly.")
+        # Get endpoint name from existing deployment
+        deployments = agents.get_deployments(UC_MODEL_NAME)
+        AGENT_ENDPOINT_NAME = deployments[0].endpoint_name if deployments else "unknown"
+        print(f"Endpoint name: {AGENT_ENDPOINT_NAME}")
     else:
         raise e
 
@@ -253,6 +258,7 @@ print(f"MLflow Experiment: {EXPERIMENT_NAME}")
 print(f"Run ID: {run.info.run_id}")
 print(f"UC Model: {UC_MODEL_NAME}")
 print(f"Model Version: {uc_registered_model_info.version}")
+print(f"Agent Endpoint: {AGENT_ENDPOINT_NAME}")
 print(f"LLM Endpoint: {LLM_ENDPOINT}")
 print(f"Vector Search Index: {VS_INDEX}")
 print("=" * 50)


### PR DESCRIPTION
## Summary
- Migrate evaluation notebook from deprecated `mlflow.evaluate()` to `mlflow.genai.evaluate()` with explicit GenAI scorers (Correctness, RelevanceToQuery, RetrievalGroundedness, RetrievalRelevance)
- Fix endpoint name discovery using `agents.get_deployments()` instead of hardcoded string manipulation
- Update deployment notebook to capture and display actual endpoint name from `deployment.endpoint_name`

## Test plan
- [x] Deploy agent using 03_deployment.py and verify endpoint name is displayed correctly
- [x] Run 04_evaluation.py and verify evaluation completes without errors
- [x] Verify metrics appear in MLflow experiment UI
- [x] Check that traces are accessible via `mlflow.search_traces()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)