### PR TITLE
Add non-DAB usage comments to src/ scripts

### DIFF
--- a/agents/openai-retrieval-agent-dabs/src/01_ingest_documents.py
+++ b/agents/openai-retrieval-agent-dabs/src/01_ingest_documents.py
@@ -31,8 +31,8 @@ from pyspark.sql.functions import (
 # COMMAND ----------
 
 # Job parameters (DAB populates these via base_parameters)
-dbutils.widgets.text("catalog", "")
-dbutils.widgets.text("schema", "")
+dbutils.widgets.text("catalog", "")  # Non-DAB: set default, e.g. "users"
+dbutils.widgets.text("schema", "")  # Non-DAB: set default, e.g. "your_schema"
 
 CATALOG = dbutils.widgets.get("catalog")
 SCHEMA = dbutils.widgets.get("schema")

--- a/agents/openai-retrieval-agent-dabs/src/02_create_vector_index.py
+++ b/agents/openai-retrieval-agent-dabs/src/02_create_vector_index.py
@@ -24,9 +24,9 @@ from databricks.vector_search.client import VectorSearchClient
 # COMMAND ----------
 
 # Job parameters (DAB populates these via base_parameters)
-dbutils.widgets.text("catalog", "")
-dbutils.widgets.text("schema", "")
-dbutils.widgets.text("vs_endpoint", "")
+dbutils.widgets.text("catalog", "")  # Non-DAB: set default, e.g. "users"
+dbutils.widgets.text("schema", "")  # Non-DAB: set default, e.g. "your_schema"
+dbutils.widgets.text("vs_endpoint", "")  # Non-DAB: set your VS endpoint name
 
 CATALOG = dbutils.widgets.get("catalog")
 SCHEMA = dbutils.widgets.get("schema")

--- a/agents/openai-retrieval-agent-dabs/src/03_deployment.py
+++ b/agents/openai-retrieval-agent-dabs/src/03_deployment.py
@@ -31,10 +31,10 @@ from mlflow.models.resources import (
 # COMMAND ----------
 
 # Job parameters (DAB populates these via base_parameters)
-dbutils.widgets.text("catalog", "")
-dbutils.widgets.text("schema", "")
-dbutils.widgets.text("experiment_name", "")
-dbutils.widgets.text("vs_endpoint", "")
+dbutils.widgets.text("catalog", "")  # Non-DAB: set default, e.g. "users"
+dbutils.widgets.text("schema", "")  # Non-DAB: set default, e.g. "your_schema"
+dbutils.widgets.text("experiment_name", "")  # Non-DAB: set, e.g. "/Users/you@email.com/my-experiment"
+dbutils.widgets.text("vs_endpoint", "")  # Non-DAB: set your VS endpoint name
 
 CATALOG = dbutils.widgets.get("catalog")
 SCHEMA = dbutils.widgets.get("schema")

--- a/agents/openai-retrieval-agent-dabs/src/04_evaluation.py
+++ b/agents/openai-retrieval-agent-dabs/src/04_evaluation.py
@@ -31,9 +31,9 @@ from mlflow.genai.scorers import (
 # COMMAND ----------
 
 # Job parameters (DAB populates these via base_parameters)
-dbutils.widgets.text("catalog", "")
-dbutils.widgets.text("schema", "")
-dbutils.widgets.text("experiment_name", "")
+dbutils.widgets.text("catalog", "")  # Non-DAB: set default, e.g. "users"
+dbutils.widgets.text("schema", "")  # Non-DAB: set default, e.g. "your_schema"
+dbutils.widgets.text("experiment_name", "")  # Non-DAB: set, e.g. "/Users/you@email.com/my-experiment"
 
 CATALOG = dbutils.widgets.get("catalog")
 SCHEMA = dbutils.widgets.get("schema")

--- a/agents/openai-retrieval-agent-dabs/src/agent.py
+++ b/agents/openai-retrieval-agent-dabs/src/agent.py
@@ -34,6 +34,7 @@ mlflow.set_registry_uri("databricks-uc")
 mlflow.set_tracking_uri("databricks")
 
 # Load configuration
+# Non-DAB: copy configs.template.yaml to configs.yaml and fill in your values
 config = mlflow.models.ModelConfig(development_config="./configs.yaml")
 databricks_config = config.get("databricks_configs")
 agent_config = config.get("agent_configs")

--- a/agents/openai-retrieval-agent-dabs/src/configs.template.yaml
+++ b/agents/openai-retrieval-agent-dabs/src/configs.template.yaml
@@ -1,12 +1,13 @@
-# Agent runtime configuration
-# Infrastructure configs (catalog, schema, workspace_url, vector_search) come from
-# DAB job parameters and are injected at deployment time via 03_deployment.py
+# Agent runtime configuration template
+# Non-DAB usage: Copy this file to configs.yaml and fill in your values
+# DAB usage: Infrastructure configs (catalog, schema, workspace_url, vector_search)
+# come from DAB job parameters and are injected at deployment time via 03_deployment.py
 
 agent_configs:
   agent_name: user-guide-retrieval-agent
   llm:
-    endpoint_name: databricks-claude-haiku-4-5
-    temperature: 0.1
+    endpoint_name: databricks-claude-haiku-4-5 
+    temperature: 0.1 
   system_prompt: |
     You are a helpful assistant that answers questions about user guides and documentation.
 


### PR DESCRIPTION
## Summary
- Added inline comments to all src/ notebook scripts explaining how to set widget defaults for non-DAB usage
- Updated configs.template.yaml with instructions for copying to configs.yaml and filling in values
- Preserves empty string defaults so existing DAB workflow continues to work

## Test plan
- [x] Verify notebooks run correctly with DAB (empty string defaults still work)
- [x] Verify non-DAB users can follow comments to set their own values
- [x] Confirm no syntax errors introduced by inline comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)