### PR TITLE
Fix display() calls to use function form

### DIFF
--- a/agents/openai-retrieval-agent-dabs/src/01_ingest_documents.py
+++ b/agents/openai-retrieval-agent-dabs/src/01_ingest_documents.py
@@ -67,7 +67,7 @@ files_df = (
 )
 
 print(f"Found {files_df.count()} PDF files")
-files_df.select("path", "length", "modificationTime").display()
+display(files_df.select("path", "length", "modificationTime"))
 
 # COMMAND ----------
 
@@ -179,7 +179,7 @@ print(f"Total chunks in table: {result_df.count()}")
 print(f"Columns: {result_df.columns}")
 
 # Show sample data
-result_df.limit(5).display()
+display(result_df.limit(5))
 
 # COMMAND ----------
 
@@ -191,4 +191,4 @@ print(f"Total documents processed: {files_df.count()}")
 print(f"Total chunks created: {result_df.count()}")
 
 # Chunks per document
-result_df.groupBy("source_path").count().orderBy("count", ascending=False).display()
+display(result_df.groupBy("source_path").count().orderBy("count", ascending=False))


### PR DESCRIPTION
## Summary
- Convert `.display()` method calls to `display(df)` function form in the document ingestion script
- The function form is more reliable in Databricks notebooks, especially during job runs and certain DBR versions

## Test plan
- [x] Run the notebook in Databricks to verify display() renders DataFrames correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)