### PR TITLE
Include AI-generated figure descriptions in document ingestion

### DIFF
--- a/agents/openai-retrieval-agent-dabs/src/01_ingest_documents.py
+++ b/agents/openai-retrieval-agent-dabs/src/01_ingest_documents.py
@@ -110,12 +110,18 @@ elements_df = (
     )
     .filter(
         expr("element:type::STRING").isin(
-            ["text", "section_header", "title", "caption"]
+            ["text", "section_header", "title", "caption", "figure"]
         )
     )
     .select(
         "source_path",
-        expr("element:content::STRING").alias("text_content"),
+        # Use description for figures (AI-generated), content for text elements
+        expr("""
+            CASE
+                WHEN element:type::STRING = 'figure' THEN element:description::STRING
+                ELSE element:content::STRING
+            END
+        """).alias("text_content"),
         expr("element:bbox[0]:page_id::INT").alias("page_number"),
     )
 )


### PR DESCRIPTION
## Summary
- Add `figure` to element type filter in document ingestion pipeline
- Extract `element:description` for figures using CASE statement (AI-generated descriptions)
- Previously, image descriptions from `ai_parse_document` were being generated but filtered out

## Test plan
- [x] Run ingestion pipeline with PDFs containing figures
- [x] Verify figure descriptions appear in `text_content` column alongside text elements
- [x] Confirm descriptions are aggregated by page with other content

🤖 Generated with [Claude Code](https://claude.com/claude-code)