### PR TITLE
Add benchmark analysis workflow to improve-genie-space skill

### DIFF
--- a/context-engineering/databricks-skills/improve-genie-space/SKILL.md
+++ b/context-engineering/databricks-skills/improve-genie-space/SKILL.md
@@ -9,9 +9,9 @@ Analyze and optimize Databricks Genie Space configurations by evaluating them ag
 
 ## Prerequisites
 
-1. **Databricks SDK**: If not installed, run:
+1. **Databricks SDK** (v0.85+): If not installed or needs updating, run:
    ```bash
-   pip install databricks-sdk
+   pip install "databricks-sdk>=0.85"
    ```
 2. **Databricks CLI profile**: Must be configured (`databricks configure`) or have environment variables set (`DATABRICKS_HOST`, `DATABRICKS_TOKEN`).
 3. **CAN EDIT permission** on the target Genie Space (required to read the serialized configuration).
@@ -31,7 +31,7 @@ python <skill_path>/scripts/fetch_space.py <space_id>
 This outputs JSON to stdout with keys: `title`, `description`, `space_id`, `serialized_space` (parsed dict).
 
 If the script fails:
-- **Missing SDK**: Prompt user to `pip install databricks-sdk`
+- **Missing SDK**: Prompt user to `pip install "databricks-sdk>=0.85"`
 - **Auth failure**: Prompt user to run `databricks configure` or check environment variables
 - **Permission denied**: User needs CAN EDIT on the space
 - **Not found**: Verify the space ID
@@ -45,8 +45,13 @@ Evaluate the space configuration against the best practices checklist. **This is
 
 Proceed to [Analyze with Best Practices](#analyze-with-best-practices).
 
-### Option B: Optimize with Benchmarks (future)
-Run benchmark questions against Genie and compare generated SQL to expected answers. **This workflow is not yet implemented.** Inform the user it will be available in a future update, and offer to run the best practices analysis instead.
+### Option B: Analyze with Benchmarks
+Run benchmark questions against Genie and compare generated SQL to expected answers.
+
+Proceed to [Analyze with Benchmarks](#analyze-with-benchmarks).
+
+### Option C: Optimize Genie Space (future)
+Create an updated Genie configuration with learnings from the config-analysis and the benchmark-analysis reports. Both reports should be present in order to run this option. Prompt the user to run the other sub-workflows first. **This workflow is not yet implemented.** Inform the user it will be available in a future update, and offer to run the best practices analysis instead.
 
 ---
 
@@ -122,5 +127,141 @@ List the top 3-5 most impactful fixes, ordered by expected improvement to Genie 
 ### Step 3e: Save Report
 
 1. Create a `reports/` directory in the user's project root if it doesn't already exist.
-2. Save the full analysis markdown (everything from Step 3d) to `reports/analysis-<space_id>.md` in the project root.
+2. Save the full analysis markdown (everything from Step 3d) to `reports/config-analysis-<space_id>.md` in the project root.
+3. Inform the user of the saved file path.
+
+---
+
+## Analyze with Benchmarks
+
+Run the space's benchmark questions against Genie via the SDK, compare generated SQL to expected SQL, and produce a detailed accuracy report.
+
+### Step 3a: Extract Benchmark Questions
+
+From the fetched space configuration, read `serialized_space.benchmarks.questions`.
+
+Parse the benchmark data format:
+- `question` is an **array of strings** — join them to get the full question text
+- `answer` is a **list of objects** — find the one with `format: "SQL"`
+- `answer[].content` is an **array of strings** — join them to get the full expected SQL
+
+If the space has no benchmarks (empty or missing `benchmarks.questions`), inform the user:
+> "This Genie Space has no benchmark questions configured. Benchmarks are question-answer pairs that let you test Genie's SQL generation accuracy. Would you like to run the best practices analysis instead?"
+
+### Step 3b: Present Benchmarks for Selection
+
+Display the benchmark questions as a numbered list:
+
+```
+Found N benchmark questions:
+  1. What are the top 5 customers by total spend?
+  2. What is the monthly revenue trend?
+  3. ...
+
+Which benchmarks would you like to run? Enter numbers (e.g., "1,3,5"), a range (e.g., "1-5"), or "all".
+```
+
+Wait for the user's selection before proceeding.
+
+### Step 3c: Run Selected Benchmarks
+
+Execute each selected benchmark question **sequentially** using the runner script:
+
+```bash
+python <skill_path>/scripts/run_benchmark.py <space_id> "<question_text>"
+```
+
+After each question completes, report progress:
+```
+[1/5] "What are the top 5 customers by total spend?" — SQL generated
+[2/5] "What is the monthly revenue trend?" — failed: <error message>
+[3/5] "Show cancelled orders from last quarter" — timed out
+```
+
+**Error handling:**
+- **Exit code 1** (script-level error: auth failure, space not found) → halt all remaining benchmarks and report the error to the user
+- **Exit code 0 with `status: "FAILED"`, `"TIMEOUT"`, or `"ERROR"`** → record the result and continue to the next question
+
+### Step 3d: Analyze Each Result
+
+For each benchmark that produced SQL (`status: "COMPLETED"` with `generated_sql` present), compare the generated SQL against the expected SQL across these dimensions:
+
+| Dimension | What to compare |
+|-----------|----------------|
+| Tables referenced | Same tables used (ignoring alias differences)? |
+| Join conditions | Same joins with equivalent conditions? |
+| WHERE clauses | Same filters applied (accounting for equivalent expressions)? |
+| Aggregations | Same aggregate functions on same columns? |
+| GROUP BY | Same grouping columns? |
+| ORDER BY | Same ordering columns and direction? |
+| LIMIT | Same row limit? |
+| Column selection | Same output columns (ignoring aliases)? |
+| Expressions | Same calculations and transformations? |
+
+Assign a verdict to each question:
+- **correct**: Generated SQL is semantically equivalent to expected SQL (may differ in formatting, aliases, or expression order)
+- **partial**: Right general approach but with meaningful differences (e.g., missing a filter, different aggregation)
+- **incorrect**: Wrong logic (wrong tables, wrong joins, wrong calculations)
+- **error**: Genie could not generate SQL (failed, timed out, or returned a text response instead)
+
+### Step 3e: Generate Benchmark Report
+
+Produce the report in this markdown format:
+
+```markdown
+# Benchmark Analysis: <space_title>
+
+**Space ID:** `<space_id>`
+**Date:** <YYYY-MM-DD>
+**Questions tested:** X of Y total benchmarks
+
+## Summary
+
+| Verdict | Count |
+|---------|-------|
+| Correct | X |
+| Partial | X |
+| Incorrect | X |
+| Error | X |
+| **Score** | **X/Y (Z%)** |
+
+Score counts correct as 1, partial as 0.5, incorrect and error as 0.
+
+## Detailed Results
+
+### 1. <question text>
+
+**Verdict:** correct | partial | incorrect | error
+
+**Expected SQL:**
+​```sql
+<expected SQL>
+​```
+
+**Generated SQL:**
+​```sql
+<generated SQL or "N/A — <reason>">
+​```
+
+**Analysis:**
+<dimensional comparison — which aspects matched, which differed, and why it matters>
+
+---
+
+### 2. <next question>
+...
+
+## Patterns & Recommendations
+
+<Identify recurring issues across the benchmark results. For example:>
+- If multiple questions missed a specific join, recommend adding a join spec
+- If aggregations are consistently wrong, recommend adding example SQLs
+- If certain tables are never used correctly, recommend improving table/column descriptions
+- Link recommendations to specific Genie Space configuration changes
+```
+
+### Step 3f: Save Report
+
+1. Create a `reports/` directory in the user's project root if it doesn't already exist.
+2. Save the full report markdown to `reports/benchmark-analysis-<space_id>.md` in the project root.
 3. Inform the user of the saved file path.

--- a/context-engineering/databricks-skills/improve-genie-space/references/space-schema.md
+++ b/context-engineering/databricks-skills/improve-genie-space/references/space-schema.md
@@ -25,8 +25,8 @@ Space-level configuration.
   "config": {
     "sample_questions": [
       {
-        "id": "q1",
-        "question": "What are the top 10 products by revenue?"
+        "id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+        "question": ["What are the top 10 products by revenue?"]
       }
     ]
   }
@@ -36,8 +36,8 @@ Space-level configuration.
 | Field | Type | Description |
 |-------|------|-------------|
 | `sample_questions` | array | Questions shown in the Genie UI as starting points |
-| `sample_questions[].id` | string | Unique identifier for the question |
-| `sample_questions[].question` | string | The question text displayed to users |
+| `sample_questions[].id` | string | 32-char lowercase hex identifier |
+| `sample_questions[].question` | array of strings | The question text displayed to users |
 
 ---
 
@@ -52,23 +52,29 @@ Tables, columns, and metric views available to Genie.
   "data_sources": {
     "tables": [
       {
-        "name": "catalog.schema.table_name",
-        "description": "Human-readable table description",
-        "columns": [
+        "id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+        "identifier": "catalog.schema.table_name",
+        "description": ["Human-readable table description"],
+        "column_configs": [
           {
-            "name": "column_name",
-            "description": "What this column contains",
+            "id": "b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a7",
+            "column_name": "column_name",
+            "description": ["What this column contains"],
             "synonyms": ["alias1", "alias2"],
             "get_example_values": true,
-            "build_value_dictionary": true
+            "build_value_dictionary": true,
+            "exclude": false,
+            "enable_entity_matching": false,
+            "enable_format_assistance": false
           }
         ]
       }
     ],
     "metric_views": [
       {
-        "name": "catalog.schema.metric_view_name",
-        "description": "What this metric view computes"
+        "id": "c3d4e5f6a7b8c9d0e1f2a3b4c5d6a7b8",
+        "identifier": "catalog.schema.metric_view_name",
+        "description": ["What this metric view computes"]
       }
     ]
   }
@@ -78,17 +84,23 @@ Tables, columns, and metric views available to Genie.
 | Field | Type | Description |
 |-------|------|-------------|
 | `tables` | array | Unity Catalog tables exposed to Genie |
-| `tables[].name` | string | Fully qualified table name (`catalog.schema.table`) |
-| `tables[].description` | string | Human-readable description of the table |
-| `tables[].columns` | array | Column definitions with metadata |
-| `tables[].columns[].name` | string | Column name |
-| `tables[].columns[].description` | string | Contextual description beyond the column name |
-| `tables[].columns[].synonyms` | array of strings | Alternative names users might use |
-| `tables[].columns[].get_example_values` | boolean | Whether Genie fetches sample values for this column |
-| `tables[].columns[].build_value_dictionary` | boolean | Whether Genie builds a dictionary of discrete values |
+| `tables[].id` | string | 32-char lowercase hex identifier |
+| `tables[].identifier` | string | Fully qualified table name (`catalog.schema.table`) |
+| `tables[].description` | array of strings | Human-readable description of the table |
+| `tables[].column_configs` | array | Column definitions with metadata |
+| `tables[].column_configs[].id` | string | 32-char lowercase hex identifier |
+| `tables[].column_configs[].column_name` | string | Column name |
+| `tables[].column_configs[].description` | array of strings | Contextual description beyond the column name |
+| `tables[].column_configs[].synonyms` | array of strings | Alternative names users might use |
+| `tables[].column_configs[].get_example_values` | boolean | Whether Genie fetches sample values for this column |
+| `tables[].column_configs[].build_value_dictionary` | boolean | Whether Genie builds a dictionary of discrete values |
+| `tables[].column_configs[].exclude` | boolean | Whether to hide this column from Genie |
+| `tables[].column_configs[].enable_entity_matching` | boolean | Whether Genie matches user terms to column values |
+| `tables[].column_configs[].enable_format_assistance` | boolean | Whether Genie applies format hints for this column |
 | `metric_views` | array | Pre-computed metric views |
-| `metric_views[].name` | string | Fully qualified metric view name |
-| `metric_views[].description` | string | What the metric view computes |
+| `metric_views[].id` | string | 32-char lowercase hex identifier |
+| `metric_views[].identifier` | string | Fully qualified metric view name |
+| `metric_views[].description` | array of strings | What the metric view computes |
 
 ---
 
@@ -103,7 +115,8 @@ Guidance that shapes how Genie interprets questions and generates SQL.
   "instructions": {
     "text_instructions": [
       {
-        "content": "Revenue is calculated as quantity * unit_price. Always filter out cancelled orders unless explicitly requested."
+        "id": "d4e5f6a7b8c9d0e1f2a3b4c5d6a7b8c9",
+        "content": ["Revenue is calculated as quantity * unit_price.", "Always filter out cancelled orders unless explicitly requested."]
       }
     ]
   }
@@ -113,22 +126,26 @@ Guidance that shapes how Genie interprets questions and generates SQL.
 | Field | Type | Description |
 |-------|------|-------------|
 | `text_instructions` | array | Free-text instructions applied globally |
-| `text_instructions[].content` | string | The instruction text |
+| `text_instructions[].id` | string | 32-char lowercase hex identifier |
+| `text_instructions[].content` | array of strings | The instruction text segments |
 
-### Example SQLs
+### Example Question SQLs
 
 ```json
 {
   "instructions": {
-    "example_sqls": [
+    "example_question_sqls": [
       {
-        "question": "What is the monthly revenue trend for the last year?",
-        "sql": "SELECT DATE_TRUNC('month', order_date) AS month, SUM(quantity * unit_price) AS revenue FROM catalog.schema.orders WHERE order_date >= DATE_ADD(CURRENT_DATE(), -365) GROUP BY 1 ORDER BY 1",
-        "usage_guidance": "Use this pattern for any time-series trend question involving revenue or sales amounts",
+        "id": "e5f6a7b8c9d0e1f2a3b4c5d6a7b8c9d0",
+        "question": ["What is the monthly revenue trend for the last year?"],
+        "sql": ["SELECT DATE_TRUNC('month', order_date) AS month, ", "SUM(quantity * unit_price) AS revenue ", "FROM catalog.schema.orders ", "WHERE order_date >= DATE_ADD(CURRENT_DATE(), -365) ", "GROUP BY 1 ORDER BY 1"],
+        "usage_guidance": ["Use this pattern for any time-series trend question involving revenue or sales amounts"],
         "parameters": [
           {
             "name": "time_period",
-            "description": "The time granularity (day, week, month, quarter, year)"
+            "description": "The time granularity (day, week, month, quarter, year)",
+            "type_hint": "STRING",
+            "default_value": { "values": ["month"] }
           }
         ]
       }
@@ -139,13 +156,16 @@ Guidance that shapes how Genie interprets questions and generates SQL.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `example_sqls` | array | Question-SQL pairs that teach Genie query patterns |
-| `example_sqls[].question` | string | Natural language question |
-| `example_sqls[].sql` | string | The SQL query that answers the question |
-| `example_sqls[].usage_guidance` | string | When Genie should apply this pattern |
-| `example_sqls[].parameters` | array | Parameterized values in the query |
-| `example_sqls[].parameters[].name` | string | Parameter name |
-| `example_sqls[].parameters[].description` | string | What the parameter represents |
+| `example_question_sqls` | array | Question-SQL pairs that teach Genie query patterns |
+| `example_question_sqls[].id` | string | 32-char lowercase hex identifier |
+| `example_question_sqls[].question` | array of strings | Natural language question segments |
+| `example_question_sqls[].sql` | array of strings | The SQL query segments (join to form full query) |
+| `example_question_sqls[].usage_guidance` | array of strings | When Genie should apply this pattern |
+| `example_question_sqls[].parameters` | array | Parameterized values in the query |
+| `example_question_sqls[].parameters[].name` | string | Parameter name |
+| `example_question_sqls[].parameters[].description` | string | What the parameter represents |
+| `example_question_sqls[].parameters[].type_hint` | string | Data type hint (e.g., `"STRING"`, `"INT"`) |
+| `example_question_sqls[].parameters[].default_value` | object | Default value with `values` array |
 
 ### Join Specs
 
@@ -154,11 +174,19 @@ Guidance that shapes how Genie interprets questions and generates SQL.
   "instructions": {
     "join_specs": [
       {
-        "left_table": "catalog.schema.orders",
-        "right_table": "catalog.schema.customers",
+        "id": "f6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1",
+        "left": {
+          "identifier": "catalog.schema.orders",
+          "alias": "orders"
+        },
+        "right": {
+          "identifier": "catalog.schema.customers",
+          "alias": "customers"
+        },
         "join_type": "LEFT JOIN",
-        "condition": "orders.customer_id = customers.id",
-        "comment": "Link orders to customer details; use LEFT JOIN to include orders with unknown customers"
+        "sql": ["orders.customer_id = customers.id"],
+        "comment": ["Link orders to customer details; use LEFT JOIN to include orders with unknown customers"],
+        "instruction": ["Always use this join when relating orders to customer demographics"]
       }
     ]
   }
@@ -168,11 +196,15 @@ Guidance that shapes how Genie interprets questions and generates SQL.
 | Field | Type | Description |
 |-------|------|-------------|
 | `join_specs` | array | Explicit join definitions for multi-table queries |
-| `join_specs[].left_table` | string | Left table in the join |
-| `join_specs[].right_table` | string | Right table in the join |
+| `join_specs[].id` | string | 32-char lowercase hex identifier |
+| `join_specs[].left.identifier` | string | Left table fully qualified name |
+| `join_specs[].left.alias` | string | Alias for the left table in the join |
+| `join_specs[].right.identifier` | string | Right table fully qualified name |
+| `join_specs[].right.alias` | string | Alias for the right table in the join |
 | `join_specs[].join_type` | string | Join type (INNER JOIN, LEFT JOIN, etc.) |
-| `join_specs[].condition` | string | Join condition expression |
-| `join_specs[].comment` | string | Business context for the relationship |
+| `join_specs[].sql` | array of strings | Join condition expression segments |
+| `join_specs[].comment` | array of strings | Business context for the relationship |
+| `join_specs[].instruction` | array of strings | Guidance on when/how to use this join |
 
 ### SQL Functions
 
@@ -181,7 +213,8 @@ Guidance that shapes how Genie interprets questions and generates SQL.
   "instructions": {
     "sql_functions": [
       {
-        "name": "catalog.schema.calculate_margin",
+        "id": "a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2",
+        "identifier": "catalog.schema.calculate_margin",
         "description": "Calculates profit margin percentage from revenue and cost"
       }
     ]
@@ -192,7 +225,8 @@ Guidance that shapes how Genie interprets questions and generates SQL.
 | Field | Type | Description |
 |-------|------|-------------|
 | `sql_functions` | array | Unity Catalog functions available to Genie |
-| `sql_functions[].name` | string | Fully qualified function name |
+| `sql_functions[].id` | string | 32-char lowercase hex identifier |
+| `sql_functions[].identifier` | string | Fully qualified function name |
 | `sql_functions[].description` | string | What the function does |
 
 ### SQL Snippets
@@ -203,23 +237,34 @@ Guidance that shapes how Genie interprets questions and generates SQL.
     "sql_snippets": {
       "filters": [
         {
-          "name": "last_30_days",
-          "content": "WHERE order_date >= DATE_ADD(CURRENT_DATE(), -30)",
-          "synonyms": ["recent", "last month", "past 30 days"]
+          "id": "b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2a3",
+          "display_name": "Last 30 Days",
+          "sql": "WHERE order_date >= DATE_ADD(CURRENT_DATE(), -30)",
+          "synonyms": ["recent", "last month", "past 30 days"],
+          "instruction": ["Apply this filter when the user asks about recent data"],
+          "comment": ["Standard recency filter for order-based queries"]
         }
       ],
       "expressions": [
         {
-          "name": "customer_segment",
-          "content": "CASE WHEN lifetime_value > 10000 THEN 'Enterprise' WHEN lifetime_value > 1000 THEN 'Mid-Market' ELSE 'SMB' END",
-          "synonyms": ["segment", "customer tier", "customer type"]
+          "id": "c9d0e1f2a3b4c5d6a7b8c9d0e1f2a3b4",
+          "alias": "customer_segment",
+          "display_name": "Customer Segment",
+          "sql": "CASE WHEN lifetime_value > 10000 THEN 'Enterprise' WHEN lifetime_value > 1000 THEN 'Mid-Market' ELSE 'SMB' END",
+          "synonyms": ["segment", "customer tier", "customer type"],
+          "instruction": ["Use this expression when classifying customers by value tier"],
+          "comment": ["Segments align with the sales team's tiering model"]
         }
       ],
       "measures": [
         {
-          "name": "total_revenue",
-          "content": "SUM(quantity * unit_price)",
-          "synonyms": ["revenue", "sales", "total sales"]
+          "id": "d0e1f2a3b4c5d6a7b8c9d0e1f2a3b4c5",
+          "alias": "total_revenue",
+          "display_name": "Total Revenue",
+          "sql": "SUM(quantity * unit_price)",
+          "synonyms": ["revenue", "sales", "total sales"],
+          "instruction": ["Use this measure for any revenue aggregation"],
+          "comment": ["Revenue includes all non-cancelled order line items"]
         }
       ]
     }
@@ -233,9 +278,18 @@ Guidance that shapes how Genie interprets questions and generates SQL.
 | `sql_snippets.filters` | array | Common WHERE clause patterns |
 | `sql_snippets.expressions` | array | Reusable CASE/calculation expressions |
 | `sql_snippets.measures` | array | Standard aggregation definitions |
-| `sql_snippets.*[].name` | string | Snippet identifier |
-| `sql_snippets.*[].content` | string | The SQL fragment |
+| `sql_snippets.*[].id` | string | 32-char lowercase hex identifier |
+| `sql_snippets.filters[].display_name` | string | Human-readable name for the filter |
+| `sql_snippets.filters[].sql` | string | The SQL fragment |
+| `sql_snippets.expressions[].alias` | string | Column alias used in generated SQL |
+| `sql_snippets.expressions[].display_name` | string | Human-readable name for the expression |
+| `sql_snippets.expressions[].sql` | string | The SQL fragment |
+| `sql_snippets.measures[].alias` | string | Column alias used in generated SQL |
+| `sql_snippets.measures[].display_name` | string | Human-readable name for the measure |
+| `sql_snippets.measures[].sql` | string | The SQL fragment |
 | `sql_snippets.*[].synonyms` | array of strings | Terms that trigger this snippet |
+| `sql_snippets.*[].instruction` | array of strings | Guidance on when to use this snippet |
+| `sql_snippets.*[].comment` | array of strings | Additional context or notes |
 
 ---
 
@@ -248,11 +302,14 @@ Q&A pairs for validating Genie's SQL generation accuracy.
   "benchmarks": {
     "questions": [
       {
-        "question": "What are the top 5 customers by total spend?",
-        "answer": {
-          "format": "SQL",
-          "content": "SELECT c.name, SUM(o.amount) AS total_spend FROM catalog.schema.customers c JOIN catalog.schema.orders o ON c.id = o.customer_id GROUP BY 1 ORDER BY 2 DESC LIMIT 5"
-        }
+        "id": "e1f2a3b4c5d6a7b8c9d0e1f2a3b4c5d6",
+        "question": ["What are the top 5 customers by total spend?"],
+        "answer": [
+          {
+            "format": "SQL",
+            "content": ["SELECT c.name, SUM(o.amount) AS total_spend ", "FROM catalog.schema.customers c ", "JOIN catalog.schema.orders o ON c.id = o.customer_id ", "GROUP BY 1 ORDER BY 2 DESC LIMIT 5"]
+          }
+        ]
       }
     ]
   }
@@ -262,7 +319,20 @@ Q&A pairs for validating Genie's SQL generation accuracy.
 | Field | Type | Description |
 |-------|------|-------------|
 | `benchmarks.questions` | array | Benchmark question-answer pairs |
-| `benchmarks.questions[].question` | string | The test question |
-| `benchmarks.questions[].answer` | object | Expected answer |
-| `benchmarks.questions[].answer.format` | string | Answer format (typically `"SQL"`) |
-| `benchmarks.questions[].answer.content` | string | The expected SQL query |
+| `benchmarks.questions[].id` | string | 32-char lowercase hex identifier (unique across sample_questions and benchmarks) |
+| `benchmarks.questions[].question` | array of strings | The test question segments (join to form full question) |
+| `benchmarks.questions[].answer` | array of objects | Expected answers (find the one with `format: "SQL"` for SQL benchmarks) |
+| `benchmarks.questions[].answer[].format` | string | Answer format (typically `"SQL"`) |
+| `benchmarks.questions[].answer[].content` | array of strings | The expected SQL query segments (join to form full query) |
+
+---
+
+## Validation Rules
+
+| Rule | Details |
+|------|---------|
+| **IDs** | 32-char lowercase hexadecimal, no hyphens (e.g., `a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6`) |
+| **Sorting** | Collections with IDs or identifiers must be sorted alphabetically |
+| **String length** | Maximum 25,000 characters per string |
+| **Array length** | Maximum 10,000 items per array |
+| **ID uniqueness** | Question IDs must be unique across `sample_questions` and `benchmarks.questions` |

--- a/context-engineering/databricks-skills/improve-genie-space/scripts/fetch_space.py
+++ b/context-engineering/databricks-skills/improve-genie-space/scripts/fetch_space.py
@@ -7,7 +7,7 @@ Output: JSON to stdout
 Exit codes: 0 success, 1 error (message to stderr)
 
 Requires:
-  - databricks-sdk (pip install databricks-sdk)
+  - databricks-sdk >= 0.85 (pip install "databricks-sdk>=0.85")
   - Databricks CLI profile configured (databricks configure)
   - CAN EDIT permission on the target Genie Space
 """
@@ -22,7 +22,7 @@ def fetch_space(space_id: str) -> dict:
         from databricks.sdk import WorkspaceClient
     except ImportError:
         print(
-            "Error: databricks-sdk is not installed. Run: pip install databricks-sdk",
+            'Error: databricks-sdk is not installed. Run: pip install "databricks-sdk>=0.85"',
             file=sys.stderr,
         )
         sys.exit(1)

--- a/context-engineering/databricks-skills/improve-genie-space/scripts/run_benchmark.py
+++ b/context-engineering/databricks-skills/improve-genie-space/scripts/run_benchmark.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Run a single benchmark question against a Databricks Genie Space.
+
+Usage: python run_benchmark.py <space_id> <question>
+Output: JSON to stdout
+Exit codes: 0 = result available (success or Genie-level failure), 1 = script-level error (stderr)
+
+Requires:
+  - databricks-sdk >= 0.85 (pip install "databricks-sdk>=0.85")
+  - Databricks CLI profile configured (databricks configure)
+  - CAN EDIT permission on the target Genie Space
+"""
+
+import json
+import sys
+from datetime import timedelta
+
+
+def run_benchmark(space_id: str, question: str) -> dict:
+    """Send a question to Genie and return the structured result."""
+    try:
+        from databricks.sdk import WorkspaceClient
+        from databricks.sdk.service.dashboards import MessageStatus
+    except ImportError:
+        print(
+            'Error: databricks-sdk is not installed. Run: pip install "databricks-sdk>=0.85"',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        client = WorkspaceClient()
+    except Exception as e:
+        print(
+            f"Error: Failed to initialize Databricks client. "
+            f"Ensure your CLI profile is configured (databricks configure).\n{e}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    result = {
+        "space_id": space_id,
+        "question": question,
+        "status": None,
+        "generated_sql": None,
+        "query_description": None,
+        "text_response": None,
+        "error": None,
+    }
+
+    try:
+        message = client.genie.start_conversation_and_wait(
+            space_id=space_id,
+            content=question,
+            timeout=timedelta(minutes=5),
+        )
+    except TimeoutError:
+        result["status"] = "TIMEOUT"
+        result["error"] = "Genie did not respond within 5 minutes"
+        return result
+    except Exception as e:
+        error_msg = str(e)
+        if "PERMISSION_DENIED" in error_msg or "403" in error_msg:
+            print(
+                f"Error: Permission denied on space '{space_id}'.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if "NOT_FOUND" in error_msg or "404" in error_msg:
+            print(
+                f"Error: Genie Space '{space_id}' not found.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        result["status"] = "ERROR"
+        result["error"] = f"SDK error: {error_msg}"
+        return result
+
+    if message.status == MessageStatus.FAILED:
+        result["status"] = "FAILED"
+        result["error"] = (
+            message.error.message if message.error else "Unknown Genie error"
+        )
+        return result
+
+    result["status"] = "COMPLETED"
+
+    if message.attachments:
+        for attachment in message.attachments:
+            if attachment.query and attachment.query.query:
+                result["generated_sql"] = attachment.query.query
+                if attachment.query.description:
+                    result["query_description"] = attachment.query.description
+                break
+            if attachment.text and attachment.text.content:
+                result["text_response"] = attachment.text.content
+
+    return result
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(
+            "Usage: python run_benchmark.py <space_id> <question>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    output = run_benchmark(sys.argv[1], sys.argv[2])
+    print(json.dumps(output, indent=2, ensure_ascii=False))


### PR DESCRIPTION
## Summary
- Implement Option B ("Analyze with Benchmarks") sub-workflow that runs benchmark questions against a Genie Space via the SDK, compares generated SQL to expected answers, and produces a scored accuracy report
- Create `scripts/run_benchmark.py` for single-question Genie API invocation using `start_conversation_and_wait`
- Correct `space-schema.md` field names, types, and structure to match official Databricks API docs (e.g., `name` → `identifier`, `columns` → `column_configs`, string fields → array of strings)
- Require `databricks-sdk >= 0.85` across all scripts and documentation

## Test plan
- [x] Run `python scripts/run_benchmark.py <space_id> "simple question"` — verify JSON output structure
- [x] Run with invalid space ID — verify stderr message and exit code 1
- [x] Trigger skill with "analyze my genie space with benchmarks", provide a space ID with benchmarks, select a subset, verify report output
- [x] Test space with no benchmarks — should gracefully suggest best practices instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)