### PR TITLE
Fix YAML frontmatter parsing error in SKILL.md

### DIFF
--- a/context-engineering/databricks-skills/improve-genie-space/SKILL.md
+++ b/context-engineering/databricks-skills/improve-genie-space/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: improve-genie-space
-description: Analyze, optimize, and improve Databricks Genie Space (AI/BI Dashboard) configurations. Use when users want to: (1) evaluate a Genie Space against best practices, (2) audit space configuration quality, (3) get recommendations for improving their Genie Space, or (4) optimize Genie Space performance. Triggers on: "improve genie space", "analyze genie space", "optimize genie", "audit genie", "review genie space", "genie best practices".
+description: 'Analyze, optimize, and improve Databricks Genie Space (AI/BI Dashboard) configurations. Use when users want to: (1) evaluate a Genie Space against best practices, (2) audit space configuration quality, (3) get recommendations for improving their Genie Space, or (4) optimize Genie Space performance. Triggers on: "improve genie space", "analyze genie space", "optimize genie", "audit genie", "review genie space", "genie best practices".'
 ---
 
 # Improve Genie Space


### PR DESCRIPTION
## Summary
- Quote the `description` value in SKILL.md YAML frontmatter to prevent colons from being interpreted as key-value separators
- Fixes GitHub rendering error: `mapping values are not allowed in this context at line 2 column 124`

## Test plan
- [x] Verify SKILL.md renders correctly on GitHub without YAML parsing errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)