### PR TITLE
Improve realism and consistency in Genie industry data generators

### DIFF
--- a/aibi/genie-demo-data/industry_data_generators/generate_hospital_readmission_data.py
+++ b/aibi/genie-demo-data/industry_data_generators/generate_hospital_readmission_data.py
@@ -325,7 +325,10 @@ for encounter in encounters_data:
     severity_mult = {"Low": 0.76, "Medium": 1.0, "High": 1.42, "Critical": 2.1}[encounter["acuity_level"]]
     allowed = base * severity_mult * PAYER_MULT[payer] * random.uniform(0.78, 1.35)
     patient_resp = allowed * {"Medicare": 0.08, "Medicaid": 0.02, "Commercial": 0.12, "Self Pay": 0.45}[payer]
-    paid_date = min(END_DATE, encounter["discharge_date"] + timedelta(days=random.randint(20, 90)))
+    claim_status = random.choices(["Paid", "Denied", "Pending"], weights=[91, 4, 5])[0]
+    paid_date = None
+    if claim_status == "Paid":
+        paid_date = min(END_DATE, encounter["discharge_date"] + timedelta(days=random.randint(20, 90)))
     claims_data.append(
         {
             "claim_id": f"CLM-{claim_counter:07d}",
@@ -336,7 +339,7 @@ for encounter in encounters_data:
             "service_line": encounter["service_line"],
             "allowed_amount_usd": round(allowed, 2),
             "patient_responsibility_usd": round(patient_resp, 2),
-            "claim_status": random.choices(["Paid", "Denied", "Pending"], weights=[91, 4, 5])[0],
+            "claim_status": claim_status,
             "paid_date": paid_date,
         }
     )

--- a/aibi/genie-demo-data/industry_data_generators/generate_retail_apparel_data.py
+++ b/aibi/genie-demo-data/industry_data_generators/generate_retail_apparel_data.py
@@ -402,6 +402,8 @@ for sale in sales_data:
     if random.random() < return_prob:
         reason = random.choices(RETURN_REASONS, weights=[33, 28, 12, 18, 9])[0]
         return_date = min(END_DATE, sale["sale_date"] + timedelta(days=random.randint(3, 45)))
+        return_qty = random.randint(1, sale["quantity"])
+        unit_net_price = sale["net_sales_usd"] / sale["quantity"]
         returns_data.append(
             {
                 "return_id": f"RTRN-{return_counter:07d}",
@@ -414,8 +416,8 @@ for sale in sales_data:
                 "store_id": sale["store_id"],
                 "channel": sale["channel"],
                 "return_reason": reason,
-                "return_quantity": sale["quantity"],
-                "return_amount_usd": sale["net_sales_usd"],
+                "return_quantity": return_qty,
+                "return_amount_usd": round(unit_net_price * return_qty, 2),
                 "days_to_return": (return_date - sale["sale_date"]).days,
             }
         )

--- a/aibi/genie-demo-data/industry_data_generators/generate_saas_churn_data.py
+++ b/aibi/genie-demo-data/industry_data_generators/generate_saas_churn_data.py
@@ -323,11 +323,17 @@ INVOICES_BY_SUB = {}
 
 for sub in subscriptions_data:
     account = ACCOUNT_BY_ID[sub["account_id"]]
-    billing_months = [MONTH_LIST[i] for i in range(0, len(MONTH_LIST), 12)] if sub["billing_term"] == "Annual" else MONTH_LIST
-    for year, month in billing_months:
+    start_month_anchor = date(sub["start_date"].year, sub["start_date"].month, 1)
+    for year, month in MONTH_LIST:
         invoice_month = date(year, month, 1)
         if invoice_month < date(sub["start_date"].year, sub["start_date"].month, 1):
             continue
+        if sub["billing_term"] == "Annual":
+            months_since_start = (invoice_month.year - start_month_anchor.year) * 12 + (
+                invoice_month.month - start_month_anchor.month
+            )
+            if months_since_start % 12 != 0:
+                continue
         amount_due = sub["monthly_recurring_revenue_usd"] * (12.0 if sub["billing_term"] == "Annual" else 1.0)
         late_prob = 0.07
         if account["segment"] == "SMB":

--- a/aibi/genie-demo-data/industry_data_generators/generate_wind_turbine_maintenance_data.py
+++ b/aibi/genie-demo-data/industry_data_generators/generate_wind_turbine_maintenance_data.py
@@ -312,12 +312,13 @@ for turbine in turbines_data:
             }
         )
         # Corrective maintenance work order tied to the failure.
+        corrective_date = min(END_DATE, failure_date + timedelta(days=random.randint(0, 4)))
         maintenance_data.append(
             {
                 "maintenance_id": f"MAINT-{maintenance_counter:07d}",
-                "maintenance_date": min(END_DATE, failure_date + timedelta(days=random.randint(0, 4))),
-                "maintenance_year": failure_date.year,
-                "maintenance_month": failure_date.month,
+                "maintenance_date": corrective_date,
+                "maintenance_year": corrective_date.year,
+                "maintenance_month": corrective_date.month,
                 "turbine_id": turbine["turbine_id"],
                 "component_id": component["component_id"],
                 "maintenance_type": "Corrective",


### PR DESCRIPTION
### Motivation

- Make the synthetic industry datasets more realistic and internally consistent for Databricks Genie demo analytics and Q&A use cases.
- Eliminate implausible temporal and financial artifacts that could distort demo metrics or confuse users.

### Description

- Hospital readmission generator: make `claim_status` explicit and populate `paid_date` only when `claim_status == 'Paid'` to avoid payment dates for denied/pending claims (`generate_hospital_readmission_data.py`).
- Retail apparel generator: support partial returns by sampling `return_quantity` between 1 and the sold quantity and compute `return_amount_usd` proportional to returned units (`generate_retail_apparel_data.py`).
- SaaS churn generator: align annual invoices to each subscription's start-month anniversary so annual billing occurs on the subscription cadence rather than a fixed calendar pattern (`generate_saas_churn_data.py`).
- Wind turbine maintenance generator: derive corrective maintenance `maintenance_year` and `maintenance_month` from the actual corrective `maintenance_date` to prevent month/year mismatches when maintenance spills into a different period (`generate_wind_turbine_maintenance_data.py`).

### Testing

- Ran syntax validation with `python -m py_compile` on the four updated scripts and the compilation succeeded for `generate_hospital_readmission_data.py`, `generate_retail_apparel_data.py`, `generate_wind_turbine_maintenance_data.py`, and `generate_saas_churn_data.py`.
- Verified diffs to ensure only the intended generator files were modified and that table schemas were preserved (schema shape unchanged by these edits).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed30e44e1c8329a16fce54bf67aaa6)