### PR TITLE
Update industry data generator notebooks

### DIFF
--- a/aibi/genie-demo-data/industry_data_generators/generate_hospital_readmission_data.py
+++ b/aibi/genie-demo-data/industry_data_generators/generate_hospital_readmission_data.py
@@ -420,11 +420,6 @@ print(f"readmissions: {len(df_readmissions)} rows")
 # =============================================================================
 # CREATE SCHEMA & WRITE DELTA TABLES
 # =============================================================================
-from pyspark.sql import SparkSession
-
-spark = SparkSession.builder.getOrCreate()
-
-spark.sql(f"CREATE CATALOG IF NOT EXISTS `{CATALOG}`")
 spark.sql(f"CREATE SCHEMA IF NOT EXISTS `{CATALOG}`.`{SCHEMA}`")
 
 

--- a/aibi/genie-demo-data/industry_data_generators/generate_retail_apparel_data.py
+++ b/aibi/genie-demo-data/industry_data_generators/generate_retail_apparel_data.py
@@ -436,11 +436,6 @@ print(f"returns: {len(df_returns)} rows")
 # =============================================================================
 # CREATE SCHEMA & WRITE DELTA TABLES
 # =============================================================================
-from pyspark.sql import SparkSession
-
-spark = SparkSession.builder.getOrCreate()
-
-spark.sql(f"CREATE CATALOG IF NOT EXISTS `{CATALOG}`")
 spark.sql(f"CREATE SCHEMA IF NOT EXISTS `{CATALOG}`.`{SCHEMA}`")
 
 

--- a/aibi/genie-demo-data/industry_data_generators/generate_saas_churn_data.py
+++ b/aibi/genie-demo-data/industry_data_generators/generate_saas_churn_data.py
@@ -457,11 +457,6 @@ print(f"churn_events: {len(df_churn_events)} rows")
 # =============================================================================
 # CREATE SCHEMA & WRITE DELTA TABLES
 # =============================================================================
-from pyspark.sql import SparkSession
-
-spark = SparkSession.builder.getOrCreate()
-
-spark.sql(f"CREATE CATALOG IF NOT EXISTS `{CATALOG}`")
 spark.sql(f"CREATE SCHEMA IF NOT EXISTS `{CATALOG}`.`{SCHEMA}`")
 
 

--- a/aibi/genie-demo-data/industry_data_generators/generate_wind_turbine_maintenance_data.py
+++ b/aibi/genie-demo-data/industry_data_generators/generate_wind_turbine_maintenance_data.py
@@ -221,6 +221,7 @@ for turbine in turbines_data:
                         "maintenance_date": event_date,
                         "maintenance_year": event_date.year,
                         "maintenance_month": event_date.month,
+                        "farm_id": turbine["farm_id"],
                         "turbine_id": turbine["turbine_id"],
                         "component_id": component["component_id"],
                         "maintenance_type": event_type,
@@ -319,6 +320,7 @@ for turbine in turbines_data:
                 "maintenance_date": corrective_date,
                 "maintenance_year": corrective_date.year,
                 "maintenance_month": corrective_date.month,
+                "farm_id": turbine["farm_id"],
                 "turbine_id": turbine["turbine_id"],
                 "component_id": component["component_id"],
                 "maintenance_type": "Corrective",
@@ -427,11 +429,6 @@ print(f"sensor_readings: {len(df_sensor_readings)} rows")
 # =============================================================================
 # CREATE SCHEMA & WRITE DELTA TABLES
 # =============================================================================
-from pyspark.sql import SparkSession
-
-spark = SparkSession.builder.getOrCreate()
-
-spark.sql(f"CREATE CATALOG IF NOT EXISTS `{CATALOG}`")
 spark.sql(f"CREATE SCHEMA IF NOT EXISTS `{CATALOG}`.`{SCHEMA}`")
 
 
@@ -610,7 +607,7 @@ joins:
     on: source.turbine_id = turbine.turbine_id
   - name: farm
     source: {CATALOG}.{SCHEMA}.wind_farms
-    on: turbine.farm_id = farm.farm_id
+    on: source.farm_id = farm.farm_id
   - name: component
     source: {CATALOG}.{SCHEMA}.components
     on: source.component_id = component.component_id
@@ -723,6 +720,7 @@ FOREIGN_KEYS = [
     ("components", "turbine_id", "turbines", "turbine_id"),
     ("sensor_readings", "farm_id", "wind_farms", "farm_id"),
     ("sensor_readings", "turbine_id", "turbines", "turbine_id"),
+    ("maintenance_events", "farm_id", "wind_farms", "farm_id"),
     ("maintenance_events", "turbine_id", "turbines", "turbine_id"),
     ("maintenance_events", "component_id", "components", "component_id"),
     ("failure_events", "farm_id", "wind_farms", "farm_id"),


### PR DESCRIPTION
## Summary
- Removed notebook-level catalog creation from the four industry data generator notebooks while keeping schema creation in place.
- Fixed the wind turbine maintenance metric view by adding `farm_id` to `maintenance_events` and joining farms from the metric view source.
- Added the matching `maintenance_events.farm_id` foreign key for the wind dataset.

## Testing
- Static checks confirmed the removed `SparkSession` and catalog-creation lines are gone from the four target files.
- Notebook markers remained intact.
- Python syntax compilation passed for all four notebook-exported `.py` files.