### PR TITLE
Updated genie caching code with Codex

### DIFF
--- a/aibi/genie-query-caching/0_setup.py
+++ b/aibi/genie-query-caching/0_setup.py
@@ -2,7 +2,7 @@
 # MAGIC %md
 # MAGIC # Genie Query Caching — Setup
 # MAGIC
-# MAGIC Creates all required infrastructure for the 3 caching scenarios:
+# MAGIC Creates the infrastructure for the 3 caching scenarios.
 # MAGIC
 # MAGIC | Resource | Used by |
 # MAGIC |----------|---------|
@@ -12,11 +12,14 @@
 # MAGIC | Delta table `cache_knowledge_base` | Scenario 3 |
 # MAGIC | Vector Search endpoint + indexes | Scenarios 2 & 3 |
 # MAGIC
+# MAGIC By default this notebook creates empty cache stores. Set `seed_demo_data: true`
+# MAGIC in `configs.yaml` only when you want the scenario notebooks to start with hits.
+# MAGIC
 # MAGIC **Prerequisites:**
-# MAGIC - Copy `configs.template.yaml` → `configs.yaml` and fill in your values
-# MAGIC - A Lakebase instance with the pgvector extension available
+# MAGIC - Copy `configs.template.yaml` to `configs.yaml` and fill in your values
+# MAGIC - A Lakebase instance with pgvector available
 # MAGIC - A Databricks secret scope with Lakebase credentials
-# MAGIC - Run on **Serverless** or a cluster with network access to Lakebase
+# MAGIC - Run on Serverless or a cluster with network access to Lakebase
 
 # COMMAND ----------
 
@@ -31,33 +34,46 @@
 # COMMAND ----------
 
 from utils import (
-    generate_id,
+    GLOBAL_SCOPE,
+    build_cache_context,
+    data_schema_name,
+    delta_cache_upsert,
     get_lakebase_connection,
     lakebase_cache_write,
     load_config,
-    normalize_question,
     sync_vs_index_and_wait,
-    utcnow,
+    table_name,
 )
 
 config = load_config("./configs.yaml")
+context = build_cache_context(config)
 
 CATALOG = config["catalog"]
 SCHEMA = config["schema"]
 VS_ENDPOINT = config["vs_endpoint"]
 EMBEDDING_MODEL = config.get("embedding_model", "databricks-qwen3-embedding-0-6b")
 EMBEDDING_DIM = config.get("embedding_dimension", 1024)
+SEED_DEMO_DATA = bool(config.get("seed_demo_data", False))
 
-print(f"Catalog:          {CATALOG}")
-print(f"Schema:           {SCHEMA}")
-print(f"VS Endpoint:      {VS_ENDPOINT}")
-print(f"Embedding Model:  {EMBEDDING_MODEL}")
-print(f"Embedding Dim:    {EMBEDDING_DIM}")
+CACHE_STORE_TABLE = table_name(config, "cache_store")
+CACHE_KB_TABLE = table_name(config, "cache_knowledge_base")
+CACHE_STORE_INDEX = f"{CATALOG}.{SCHEMA}.cache_store_index"
+CACHE_KB_INDEX = f"{CATALOG}.{SCHEMA}.cache_knowledge_base_index"
+
+print(f"Catalog:           {CATALOG}")
+print(f"Schema:            {SCHEMA}")
+print(f"Data schema:       {data_schema_name(config)}")
+print(f"Cache version:     {context.cache_version}")
+print(f"Cache context key: {context.cache_context_key}")
+print(f"VS Endpoint:       {VS_ENDPOINT}")
+print(f"Embedding Model:   {EMBEDDING_MODEL}")
+print(f"Embedding Dim:     {EMBEDDING_DIM}")
+print(f"Seed demo data:    {SEED_DEMO_DATA}")
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Create Catalog & Schema
+# MAGIC ## Create Catalog and Schema
 
 # COMMAND ----------
 
@@ -68,122 +84,176 @@ print(f"Catalog and schema ready: {CATALOG}.{SCHEMA}")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Create Delta Table — `cache_store` (Scenario 2)
+# MAGIC ## Delta Cache Tables
 # MAGIC
-# MAGIC Stores cached Genie responses for the Vector Search caching scenario.
-# MAGIC Change Data Feed (CDF) is enabled so the Delta Sync VS index can track changes.
+# MAGIC These v2 tables store cache metadata and generated SQL. They do not store an
+# MAGIC authoritative result. Scenario notebooks re-execute cached SQL on every hit.
 
 # COMMAND ----------
 
-CACHE_STORE_TABLE = f"{CATALOG}.{SCHEMA}.cache_store"
+DELTA_CACHE_COLUMNS = {
+    "id",
+    "space_id",
+    "cache_context_key",
+    "cache_scope",
+    "session_id",
+    "question_text",
+    "question_normalized",
+    "generated_sql",
+    "genie_response_text",
+    "validated",
+    "validation_source",
+    "created_at",
+    "updated_at",
+    "last_hit_at",
+    "hit_count",
+}
 
-spark.sql(f"""
-    CREATE TABLE IF NOT EXISTS {CACHE_STORE_TABLE} (
-        id STRING NOT NULL,
-        question_text STRING,
-        question_normalized STRING,
-        cached_sql STRING,
-        cached_response STRING,
-        created_at TIMESTAMP,
-        hit_count INT DEFAULT 0
-    )
-    USING DELTA
-    TBLPROPERTIES (delta.enableChangeDataFeed = true)
-""")
-print(f"Delta table ready: {CACHE_STORE_TABLE}")
+
+def assert_delta_table_compatible(full_table_name: str):
+    try:
+        existing_columns = {field.name for field in spark.table(full_table_name).schema.fields}
+    except Exception as e:
+        if "TABLE_OR_VIEW_NOT_FOUND" in str(e) or "not found" in str(e).lower():
+            return
+        raise
+
+    missing = sorted(DELTA_CACHE_COLUMNS - existing_columns)
+    if missing:
+        raise RuntimeError(
+            f"{full_table_name} already exists with a v1/incompatible schema. "
+            f"Missing columns: {missing}. Drop or migrate this cache table, then rerun setup."
+        )
+
+
+def create_delta_cache_table(full_table_name: str):
+    assert_delta_table_compatible(full_table_name)
+    spark.sql(f"""
+        CREATE TABLE IF NOT EXISTS {full_table_name} (
+            id STRING NOT NULL,
+            space_id STRING NOT NULL,
+            cache_context_key STRING NOT NULL,
+            cache_scope STRING NOT NULL,
+            session_id STRING NOT NULL,
+            question_text STRING NOT NULL,
+            question_normalized STRING NOT NULL,
+            generated_sql STRING NOT NULL,
+            genie_response_text STRING,
+            validated BOOLEAN DEFAULT false,
+            validation_source STRING,
+            created_at TIMESTAMP,
+            updated_at TIMESTAMP,
+            last_hit_at TIMESTAMP,
+            hit_count INT DEFAULT 0
+        )
+        USING DELTA
+        TBLPROPERTIES (delta.enableChangeDataFeed = true)
+    """)
+    print(f"Delta table ready: {full_table_name}")
+
+
+create_delta_cache_table(CACHE_STORE_TABLE)
+create_delta_cache_table(CACHE_KB_TABLE)
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Create Delta Table — `cache_knowledge_base` (Scenario 3)
+# MAGIC ## Lakebase Table with pgvector
 # MAGIC
-# MAGIC Long-lived knowledge base of validated cache entries.  Entries are promoted
-# MAGIC here from the L1 session cache after user validation or repeated use.
+# MAGIC The v2 unique key includes Genie space, cache context, scope, session, and
+# MAGIC normalized question. This keeps Scenario 3's session cache isolated.
 
 # COMMAND ----------
 
-CACHE_KB_TABLE = f"{CATALOG}.{SCHEMA}.cache_knowledge_base"
+LAKEBASE_CACHE_COLUMNS = {
+    "id",
+    "space_id",
+    "cache_context_key",
+    "cache_scope",
+    "session_id",
+    "question_text",
+    "question_normalized",
+    "embedding",
+    "generated_sql",
+    "genie_response_text",
+    "validated",
+    "validation_source",
+    "created_at",
+    "updated_at",
+    "last_hit_at",
+    "hit_count",
+}
 
-spark.sql(f"""
-    CREATE TABLE IF NOT EXISTS {CACHE_KB_TABLE} (
-        id STRING NOT NULL,
-        question_text STRING,
-        question_normalized STRING,
-        cached_sql STRING,
-        cached_response STRING,
-        validated BOOLEAN DEFAULT false,
-        validation_source STRING,
-        created_at TIMESTAMP,
-        hit_count INT DEFAULT 0
-    )
-    USING DELTA
-    TBLPROPERTIES (delta.enableChangeDataFeed = true)
-""")
-print(f"Delta table ready: {CACHE_KB_TABLE}")
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## Setup Lakebase Table with pgvector (Scenarios 1 & 3)
-# MAGIC
-# MAGIC Creates the `genie_cache` table in Lakebase (Databricks-managed PostgreSQL)
-# MAGIC with the pgvector extension for vector similarity search.
-# MAGIC
-# MAGIC - **HNSW index** on the embedding column for fast approximate nearest-neighbor search
-# MAGIC - **B-tree index** on `question_normalized` for exact-match lookups
-# MAGIC - **UNIQUE constraint** on `question_normalized` to support `ON CONFLICT` upserts
-
-# COMMAND ----------
 
 conn = get_lakebase_connection(config)
 try:
     with conn.cursor() as cur:
-        # Enable pgvector extension
         cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
 
-        # Create cache table
+        cur.execute("""
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = 'genie_cache'
+        """)
+        existing_columns = {row[0] for row in cur.fetchall()}
+        missing = sorted(LAKEBASE_CACHE_COLUMNS - existing_columns) if existing_columns else []
+        if missing:
+            raise RuntimeError(
+                "Lakebase table genie_cache already exists with a v1/incompatible schema. "
+                f"Missing columns: {missing}. Drop or migrate the Lakebase table, then rerun setup."
+            )
+
         cur.execute(f"""
             CREATE TABLE IF NOT EXISTS genie_cache (
-                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-                question_normalized TEXT NOT NULL UNIQUE,
+                id UUID PRIMARY KEY,
+                space_id TEXT NOT NULL,
+                cache_context_key TEXT NOT NULL,
+                cache_scope TEXT NOT NULL,
+                session_id TEXT NOT NULL DEFAULT '',
+                question_text TEXT NOT NULL,
+                question_normalized TEXT NOT NULL,
                 embedding vector({EMBEDDING_DIM}),
-                cached_sql TEXT,
-                cached_response JSONB,
-                session_id TEXT,
+                generated_sql TEXT NOT NULL,
+                genie_response_text TEXT,
+                validated BOOLEAN DEFAULT false,
+                validation_source TEXT,
                 created_at TIMESTAMPTZ DEFAULT now(),
-                hit_count INTEGER DEFAULT 0
+                updated_at TIMESTAMPTZ DEFAULT now(),
+                last_hit_at TIMESTAMPTZ,
+                hit_count INTEGER DEFAULT 0,
+                UNIQUE (
+                    space_id,
+                    cache_context_key,
+                    cache_scope,
+                    session_id,
+                    question_normalized
+                )
             )
         """)
 
-        # HNSW index for vector similarity search
         cur.execute("""
             CREATE INDEX IF NOT EXISTS idx_genie_cache_embedding
             ON genie_cache USING hnsw (embedding vector_cosine_ops)
             WITH (m = 16, ef_construction = 64)
         """)
-
-        # B-tree index on session_id for session-scoped queries (Scenario 3)
         cur.execute("""
-            CREATE INDEX IF NOT EXISTS idx_genie_cache_session
-            ON genie_cache (session_id)
+            CREATE INDEX IF NOT EXISTS idx_genie_cache_context
+            ON genie_cache (space_id, cache_context_key, cache_scope, session_id)
         """)
 
     conn.commit()
-    print("Lakebase table 'genie_cache' ready with pgvector HNSW index")
-
-    # Connectivity check: verify table exists
     with conn.cursor() as cur:
         cur.execute("SELECT count(*) FROM genie_cache")
         count = cur.fetchone()[0]
-        print(f"  Current row count: {count}")
-
+        print(f"Lakebase genie_cache ready with pgvector ({count} rows)")
 finally:
     conn.close()
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Create Vector Search Endpoint
+# MAGIC ## Vector Search Endpoint and Indexes
 
 # COMMAND ----------
 
@@ -195,7 +265,6 @@ vsc = VectorSearchClient(disable_notice=True)
 
 
 def wait_for_endpoint_ready(endpoint_name: str, timeout_minutes: int = 30):
-    """Wait for a Vector Search endpoint to reach ONLINE state."""
     start_time = time.time()
     timeout_seconds = timeout_minutes * 60
 
@@ -215,10 +284,8 @@ def wait_for_endpoint_ready(endpoint_name: str, timeout_minutes: int = 30):
         time.sleep(30)
 
 
-# COMMAND ----------
-
 try:
-    endpoint = vsc.get_endpoint(VS_ENDPOINT)
+    vsc.get_endpoint(VS_ENDPOINT)
     print(f"Endpoint {VS_ENDPOINT} already exists")
 except Exception as e:
     if "NOT_FOUND" in str(e) or "does not exist" in str(e).lower():
@@ -231,18 +298,26 @@ wait_for_endpoint_ready(VS_ENDPOINT)
 
 # COMMAND ----------
 
-# MAGIC %md
-# MAGIC ## Create Vector Search Indexes
-# MAGIC
-# MAGIC Two Delta Sync indexes with managed embeddings on `question_text`:
-# MAGIC 1. `cache_store_index` — for Scenario 2
-# MAGIC 2. `cache_knowledge_base_index` — for Scenario 3 (L2)
-
-# COMMAND ----------
+VS_COLUMNS_TO_SYNC = [
+    "id",
+    "space_id",
+    "cache_context_key",
+    "cache_scope",
+    "session_id",
+    "question_text",
+    "question_normalized",
+    "generated_sql",
+    "genie_response_text",
+    "validated",
+    "validation_source",
+    "created_at",
+    "updated_at",
+    "last_hit_at",
+    "hit_count",
+]
 
 
 def wait_for_index_ready(endpoint_name: str, index_name: str, timeout_minutes: int = 60):
-    """Wait for a Vector Search index to be ready."""
     start_time = time.time()
     timeout_seconds = timeout_minutes * 60
 
@@ -265,10 +340,10 @@ def wait_for_index_ready(endpoint_name: str, index_name: str, timeout_minutes: i
 
 
 def create_or_sync_index(source_table: str, index_name: str):
-    """Create a Delta Sync VS index or trigger sync if it already exists."""
     try:
         index = vsc.get_index(endpoint_name=VS_ENDPOINT, index_name=index_name)
-        print(f"Index {index_name} already exists — triggering sync...")
+        print(f"Index {index_name} already exists; triggering sync...")
+        print("  If this index was created before the v2 schema, delete it and rerun setup.")
         index.sync()
     except Exception as e:
         if "NOT_FOUND" in str(e) or "does not exist" in str(e).lower():
@@ -281,101 +356,66 @@ def create_or_sync_index(source_table: str, index_name: str):
                 pipeline_type="TRIGGERED",
                 embedding_source_column="question_text",
                 embedding_model_endpoint_name=EMBEDDING_MODEL,
+                columns_to_sync=VS_COLUMNS_TO_SYNC,
             )
         else:
             raise
 
 
-# COMMAND ----------
-
-# Scenario 2 index
-CACHE_STORE_INDEX = f"{CATALOG}.{SCHEMA}.cache_store_index"
 create_or_sync_index(CACHE_STORE_TABLE, CACHE_STORE_INDEX)
-
-# COMMAND ----------
-
-# Scenario 3 index
-CACHE_KB_INDEX = f"{CATALOG}.{SCHEMA}.cache_knowledge_base_index"
 create_or_sync_index(CACHE_KB_TABLE, CACHE_KB_INDEX)
-
-# COMMAND ----------
-
-# Wait for both indexes
 wait_for_index_ready(VS_ENDPOINT, CACHE_STORE_INDEX)
 wait_for_index_ready(VS_ENDPOINT, CACHE_KB_INDEX)
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Seed Demo Data
+# MAGIC ## Optional Seed Demo Data
 # MAGIC
-# MAGIC Pre-populates all 3 cache stores with 5 seed entries so the scenario
-# MAGIC notebooks show cache **HITs** immediately on the first pass.
-# MAGIC
-# MAGIC | Store | Scenario | Seeding method |
-# MAGIC |-------|----------|----------------|
-# MAGIC | Lakebase `genie_cache` (pgvector) | 1 & 3 | `lakebase_cache_write()` — upsert with real embeddings |
-# MAGIC | Delta `cache_store` | 2 | Spark append (with duplicate check) |
-# MAGIC | Delta `cache_knowledge_base` | 3 | Spark append (with duplicate check) + `validated=True` |
+# MAGIC Seed rows use the Horizon Bank semantic layer where possible. Seeded mode is
+# MAGIC useful for showing immediate hits; leave `seed_demo_data: false` to exercise
+# MAGIC the cold path and Genie API calls.
 
 # COMMAND ----------
 
-# The seed SQL references the Horizon Bank data schema (from genie-demo-data),
-# which is separate from the cache schema. Adjust DATA_SCHEMA if your Horizon
-# Bank tables live in a different schema.
-DATA_SCHEMA = "horizon_bank"
-ds = f"{CATALOG}.{DATA_SCHEMA}"
+ds = data_schema_name(config)
 
 SEED_ENTRIES = [
     {
         "question_text": "What was total deposit volume in 2024?",
-        "cached_sql": (
-            f"SELECT SUM(amount_usd) AS total_deposit_volume\n"
-            f"FROM {ds}.transactions\n"
-            f"WHERE transaction_type = 'Deposit'\n"
-            f"  AND transaction_year = 2024"
+        "generated_sql": (
+            f"SELECT MEASURE(`Deposit Volume`) AS deposit_volume\n"
+            f"FROM {ds}.mv_banking_transactions\n"
+            f"WHERE `Transaction Year` = 2024"
         ),
-        "response_text": (
-            "The total deposit volume in 2024 was approximately $15.2 million "
-            "across all accounts and branches."
-        ),
+        "response_text": "Seeded validated SQL for 2024 deposit volume.",
     },
     {
         "question_text": "Show monthly deposit trend from Jan 2023 to Dec 2025",
-        "cached_sql": (
-            f"SELECT transaction_year, transaction_month,\n"
-            f"       SUM(amount_usd) AS monthly_deposit_volume\n"
-            f"FROM {ds}.transactions\n"
-            f"WHERE transaction_type = 'Deposit'\n"
-            f"GROUP BY transaction_year, transaction_month\n"
-            f"ORDER BY transaction_year, transaction_month"
+        "generated_sql": (
+            f"SELECT `Transaction Year`, `Transaction Month`,\n"
+            f"       MEASURE(`Deposit Volume`) AS deposit_volume\n"
+            f"FROM {ds}.mv_banking_transactions\n"
+            f"WHERE `Transaction Month` BETWEEN DATE '2023-01-01' AND DATE '2025-12-01'\n"
+            f"GROUP BY `Transaction Year`, `Transaction Month`\n"
+            f"ORDER BY `Transaction Year`, `Transaction Month`"
         ),
-        "response_text": (
-            "Here is the monthly deposit trend from January 2023 through "
-            "December 2025. Notable patterns include seasonal spikes in "
-            "November/December and a Q2 2024 dip of approximately 15%."
-        ),
+        "response_text": "Seeded validated SQL for monthly deposit trend.",
     },
     {
         "question_text": "What is the average account balance for Private Client customers by state?",
-        "cached_sql": (
-            f"SELECT c.state,\n"
-            f"       ROUND(AVG(a.current_balance_usd), 2) AS avg_balance\n"
-            f"FROM {ds}.customers c\n"
-            f"JOIN {ds}.accounts a ON c.customer_id = a.customer_id\n"
-            f"WHERE c.relationship_tier = 'Private Client'\n"
-            f"GROUP BY c.state\n"
-            f"ORDER BY avg_balance DESC"
+        "generated_sql": (
+            f"SELECT `State`, MEASURE(`Average Balance`) AS average_balance\n"
+            f"FROM {ds}.mv_customer_health\n"
+            f"WHERE `Relationship Tier` = 'Private Client'\n"
+            f"GROUP BY `State`\n"
+            f"ORDER BY average_balance DESC"
         ),
-        "response_text": (
-            "Private Client customers have average account balances roughly 3x "
-            "higher than Standard tier. The highest averages are concentrated in "
-            "New York, California, and Florida."
-        ),
+        "response_text": "Seeded validated SQL for Private Client average balances.",
     },
     {
         "question_text": "Which 10 branches had the highest deposit volume this year?",
-        "cached_sql": (
+        "generated_sql": (
             f"SELECT b.branch_name, b.region,\n"
             f"       SUM(t.amount_usd) AS deposit_volume\n"
             f"FROM {ds}.transactions t\n"
@@ -386,141 +426,67 @@ SEED_ENTRIES = [
             f"ORDER BY deposit_volume DESC\n"
             f"LIMIT 10"
         ),
-        "response_text": (
-            "The top 10 branches by deposit volume are led by the Manhattan "
-            "Financial District and Miami South branches. Southeast branches "
-            "show approximately 20% higher average transaction values."
-        ),
+        "response_text": "Seeded validated SQL for top branch deposit volume.",
     },
     {
         "question_text": "What is fee revenue per customer by relationship tier?",
-        "cached_sql": (
-            f"SELECT c.relationship_tier,\n"
-            f"       COUNT(DISTINCT c.customer_id) AS customer_count,\n"
-            f"       SUM(t.fee_usd) AS total_fee_revenue,\n"
-            f"       ROUND(SUM(t.fee_usd) / COUNT(DISTINCT c.customer_id), 2) AS fee_per_customer\n"
-            f"FROM {ds}.transactions t\n"
-            f"JOIN {ds}.accounts a ON t.account_id = a.account_id\n"
-            f"JOIN {ds}.customers c ON a.customer_id = c.customer_id\n"
-            f"WHERE t.fee_usd > 0\n"
-            f"GROUP BY c.relationship_tier\n"
-            f"ORDER BY fee_per_customer DESC"
+        "generated_sql": (
+            f"SELECT `Relationship Tier`,\n"
+            f"       MEASURE(`Fee Revenue per Customer`) AS fee_revenue_per_customer\n"
+            f"FROM {ds}.mv_banking_transactions\n"
+            f"GROUP BY `Relationship Tier`\n"
+            f"ORDER BY fee_revenue_per_customer DESC"
         ),
-        "response_text": (
-            "Fee revenue per customer varies significantly by tier. Private "
-            "Client customers generate the highest fee revenue per customer, "
-            "followed by Preferred and Standard tiers."
-        ),
+        "response_text": "Seeded validated SQL for fee revenue per customer.",
     },
 ]
 
-print(f"Defined {len(SEED_ENTRIES)} seed entries")
+print(f"Defined {len(SEED_ENTRIES)} optional seed entries")
 for i, entry in enumerate(SEED_ENTRIES, 1):
     print(f"  {i}. {entry['question_text']}")
 
 # COMMAND ----------
 
-# MAGIC %md
-# MAGIC ### Seed Lakebase pgvector (Scenarios 1 & 3)
-# MAGIC
-# MAGIC Uses `lakebase_cache_write()` which handles normalization, embedding
-# MAGIC generation via the Foundation Model API, and `ON CONFLICT` upsert.
-
-# COMMAND ----------
-
-for entry in SEED_ENTRIES:
-    print(f"  Seeding: {entry['question_text'][:60]}...")
-    lakebase_cache_write(
-        config,
-        question=entry["question_text"],
-        sql=entry["cached_sql"],
-        response_text=entry["response_text"],
-    )
-
-# Verify
-conn = get_lakebase_connection(config)
-with conn.cursor() as cur:
-    cur.execute("SELECT count(*) FROM genie_cache")
-    lb_count = cur.fetchone()[0]
-print(f"\nLakebase genie_cache: {lb_count} rows")
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ### Seed Delta `cache_store` (Scenario 2)
-# MAGIC
-# MAGIC Appends rows to the Delta table. Skips if seed data already exists
-# MAGIC (checked via row count) to avoid duplicates on re-run.
-
-# COMMAND ----------
-
-from pyspark.sql import Row
-
-existing_count = spark.sql(f"SELECT count(*) FROM {CACHE_STORE_TABLE}").collect()[0][0]
-if existing_count > 0:
-    print(f"Delta table {CACHE_STORE_TABLE} already has {existing_count} rows — skipping seed")
-else:
-    rows = []
+if SEED_DEMO_DATA:
     for entry in SEED_ENTRIES:
-        rows.append(
-            Row(
-                id=generate_id(),
-                question_text=entry["question_text"],
-                question_normalized=normalize_question(entry["question_text"]),
-                cached_sql=entry["cached_sql"],
-                cached_response=entry["response_text"],
-                created_at=utcnow(),
-                hit_count=0,
-            )
+        print(f"  Seeding: {entry['question_text'][:60]}...")
+        lakebase_cache_write(
+            config,
+            question=entry["question_text"],
+            sql=entry["generated_sql"],
+            response_text=entry["response_text"],
+            cache_scope=GLOBAL_SCOPE,
+            validated=True,
+            validation_source="seed",
         )
-    df = spark.createDataFrame(rows)
-    df.write.mode("append").saveAsTable(CACHE_STORE_TABLE)
-    print(f"Seeded {len(rows)} rows into {CACHE_STORE_TABLE}")
+        delta_cache_upsert(
+            spark,
+            CACHE_STORE_TABLE,
+            config,
+            question=entry["question_text"],
+            sql=entry["generated_sql"],
+            response_text=entry["response_text"],
+            cache_scope=GLOBAL_SCOPE,
+            validated=True,
+            validation_source="seed",
+        )
+        delta_cache_upsert(
+            spark,
+            CACHE_KB_TABLE,
+            config,
+            question=entry["question_text"],
+            sql=entry["generated_sql"],
+            response_text=entry["response_text"],
+            cache_scope=GLOBAL_SCOPE,
+            validated=True,
+            validation_source="seed",
+        )
 
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ### Seed Delta `cache_knowledge_base` (Scenario 3)
-# MAGIC
-# MAGIC Same entries but marked as `validated=True` with `validation_source="seed"`.
-
-# COMMAND ----------
-
-existing_count = spark.sql(f"SELECT count(*) FROM {CACHE_KB_TABLE}").collect()[0][0]
-if existing_count > 0:
-    print(f"Delta table {CACHE_KB_TABLE} already has {existing_count} rows — skipping seed")
+    print("\nSyncing Vector Search indexes after seed writes...")
+    sync_vs_index_and_wait(vsc, VS_ENDPOINT, CACHE_STORE_INDEX)
+    sync_vs_index_and_wait(vsc, VS_ENDPOINT, CACHE_KB_INDEX)
 else:
-    rows = []
-    for entry in SEED_ENTRIES:
-        rows.append(
-            Row(
-                id=generate_id(),
-                question_text=entry["question_text"],
-                question_normalized=normalize_question(entry["question_text"]),
-                cached_sql=entry["cached_sql"],
-                cached_response=entry["response_text"],
-                validated=True,
-                validation_source="seed",
-                created_at=utcnow(),
-                hit_count=0,
-            )
-        )
-    df = spark.createDataFrame(rows)
-    df.write.mode("append").saveAsTable(CACHE_KB_TABLE)
-    print(f"Seeded {len(rows)} rows into {CACHE_KB_TABLE}")
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ### Sync Vector Search Indexes
-
-# COMMAND ----------
-
-print("Syncing cache_store index...")
-sync_vs_index_and_wait(vsc, VS_ENDPOINT, CACHE_STORE_INDEX)
-
-print("Syncing cache_knowledge_base index...")
-sync_vs_index_and_wait(vsc, VS_ENDPOINT, CACHE_KB_INDEX)
+    print("Skipping demo seed data. Scenario notebooks will exercise cold misses first.")
 
 # COMMAND ----------
 
@@ -529,7 +495,6 @@ sync_vs_index_and_wait(vsc, VS_ENDPOINT, CACHE_KB_INDEX)
 
 # COMMAND ----------
 
-# Seed row counts
 conn = get_lakebase_connection(config)
 with conn.cursor() as cur:
     cur.execute("SELECT count(*) FROM genie_cache")
@@ -541,15 +506,17 @@ kb_count = spark.sql(f"SELECT count(*) FROM {CACHE_KB_TABLE}").collect()[0][0]
 print("=" * 60)
 print("SETUP COMPLETE")
 print("=" * 60)
-print(f"  Catalog/Schema:        {CATALOG}.{SCHEMA}")
-print(f"  Delta — cache_store:   {CACHE_STORE_TABLE} ({cs_count} rows)")
-print(f"  Delta — knowledge_base:{CACHE_KB_TABLE} ({kb_count} rows)")
-print(f"  Lakebase — genie_cache: ✓ pgvector + HNSW ({lb_count} rows)")
-print(f"  VS Endpoint:           {VS_ENDPOINT}")
-print(f"  VS Index (Scenario 2): {CACHE_STORE_INDEX}")
-print(f"  VS Index (Scenario 3): {CACHE_KB_INDEX}")
+print(f"  Catalog/Schema:         {CATALOG}.{SCHEMA}")
+print(f"  Data schema:            {data_schema_name(config)}")
+print(f"  Cache context key:      {context.cache_context_key}")
+print(f"  Delta - cache_store:    {CACHE_STORE_TABLE} ({cs_count} rows)")
+print(f"  Delta - knowledge_base: {CACHE_KB_TABLE} ({kb_count} rows)")
+print(f"  Lakebase - genie_cache: pgvector + HNSW ({lb_count} rows)")
+print(f"  VS Endpoint:            {VS_ENDPOINT}")
+print(f"  VS Index (Scenario 2):  {CACHE_STORE_INDEX}")
+print(f"  VS Index (Scenario 3):  {CACHE_KB_INDEX}")
 print()
-print("Next steps — run any scenario notebook:")
-print("  1. 1_lakebase_pgvector_cache.py  — Scenario 1: Lakebase + pgvector")
-print("  2. 2_vector_search_cache.py      — Scenario 2: Vector Search")
-print("  3. 3_hybrid_cache.py             — Scenario 3: Hybrid (Recommended)")
+print("Next steps - run any scenario notebook:")
+print("  1. 1_lakebase_pgvector_cache.py  - Scenario 1: Lakebase + pgvector")
+print("  2. 2_vector_search_cache.py      - Scenario 2: Vector Search")
+print("  3. 3_hybrid_cache.py             - Scenario 3: Hybrid (Recommended)")

--- a/aibi/genie-query-caching/1_lakebase_pgvector_cache.py
+++ b/aibi/genie-query-caching/1_lakebase_pgvector_cache.py
@@ -4,18 +4,14 @@
 # MAGIC
 # MAGIC ![Architecture](scenario1-lakebase-pgvector.png)
 # MAGIC
-# MAGIC This notebook demonstrates query caching using **Lakebase** (Databricks-managed
-# MAGIC PostgreSQL) with the **pgvector** extension.
+# MAGIC This notebook demonstrates a Lakebase cache for generated Genie SQL.
 # MAGIC
 # MAGIC **Cache flow:**
-# MAGIC 1. Normalize the incoming question
-# MAGIC 2. **Exact match** — look up `question_normalized` in Lakebase
-# MAGIC 3. **Vector similarity** — if no exact match, generate an embedding and run
-# MAGIC    cosine similarity search via pgvector (threshold ≥ 0.92)
-# MAGIC 4. **HIT** → return cached SQL / response immediately
-# MAGIC 5. **MISS** → call Genie API (with retry + backoff), cache the response
-# MAGIC
-# MAGIC **Key properties:** ACID writes, immediate read-after-write, scale-to-zero.
+# MAGIC 1. Normalize the incoming question.
+# MAGIC 2. Check Lakebase for an exact match in the current cache context.
+# MAGIC 3. If no exact match exists, generate an embedding and search with pgvector.
+# MAGIC 4. On a hit, re-execute cached SQL under the current Databricks identity.
+# MAGIC 5. On a miss, call Genie, execute the generated SQL, then cache it.
 # MAGIC
 # MAGIC **Prerequisites:** Run `0_setup.py` first.
 
@@ -34,29 +30,36 @@
 import time
 
 from utils import (
+    GLOBAL_SCOPE,
+    build_cache_context,
     call_genie_with_retry,
+    execute_cached_sql_with_trace,
     lakebase_cache_lookup,
     lakebase_cache_write,
     load_config,
+    print_sql_preview,
     print_summary_table,
+    trace_operation,
 )
 
 config = load_config("./configs.yaml")
+context = build_cache_context(config)
 
 SIMILARITY_THRESHOLD = config.get("thresholds", {}).get("lakebase_similarity", 0.92)
+RESULT_ROW_LIMIT = int(config.get("result_row_limit", 100))
 
 print(f"Genie Space:          {config['genie_space_id']}")
+print(f"Cache context key:    {context.cache_context_key}")
 print(f"Similarity threshold: {SIMILARITY_THRESHOLD}")
+print(f"Result row limit:     {RESULT_ROW_LIMIT}")
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Demo — Cold Pass (Cache Miss → Genie API)
+# MAGIC ## Demo — First Pass
 # MAGIC
-# MAGIC Each question goes through:
-# MAGIC 1. Cache lookup → expected **MISS**
-# MAGIC 2. Genie API call with retry/backoff
-# MAGIC 3. Cache write (immediate, ACID)
+# MAGIC With `seed_demo_data: false`, each question should miss and call Genie. With
+# MAGIC seeded mode enabled, matching questions may hit immediately.
 
 # COMMAND ----------
 
@@ -67,113 +70,147 @@ demo_questions = config.get("demo_questions", [
 results = []
 
 for question in demo_questions:
-    print(f"\n{'=' * 60}")
-    print(f"Question: {question}")
+    with trace_operation(config, "scenario1_question", "CHAIN", {"question": question}):
+        print(f"\n{'=' * 60}")
+        print(f"Question: {question}")
 
-    # --- Cache lookup ---
-    t0 = time.time()
-    hit_type, cached_sql, cached_resp, score, embedding = lakebase_cache_lookup(
-        config, question, threshold=SIMILARITY_THRESHOLD
-    )
+        t0 = time.time()
+        lookup = lakebase_cache_lookup(
+            config,
+            question,
+            threshold=SIMILARITY_THRESHOLD,
+            cache_scope=GLOBAL_SCOPE,
+        )
 
-    if hit_type:
+        if lookup.hit:
+            sql_result = execute_cached_sql_with_trace(
+                config, lookup.generated_sql, row_limit=RESULT_ROW_LIMIT
+            )
+            latency = time.time() - t0
+            print(f"  HIT ({lookup.hit_type}, score={lookup.score:.3f}) in {latency:.3f}s")
+            print(f"  Cached SQL: {lookup.generated_sql[:160]}...")
+            print_sql_preview(sql_result)
+            results.append({
+                "question": question[:50],
+                "first_s": latency,
+                "warm_s": None,
+                "source": f"hit-{lookup.hit_type}",
+                "speedup": "-",
+            })
+            continue
+
+        print("  MISS -> calling Genie API with retry/backoff...")
+        genie_result = call_genie_with_retry(config, question)
+        print(f"  Genie returned in {genie_result.latency_seconds:.1f}s")
+
+        if not genie_result.cacheable:
+            latency = time.time() - t0
+            print("  Genie did not return SQL; not caching this response.")
+            results.append({
+                "question": question[:50],
+                "first_s": latency,
+                "warm_s": None,
+                "source": "genie-no-sql",
+                "speedup": None,
+            })
+            continue
+
+        sql_result = execute_cached_sql_with_trace(
+            config, genie_result.generated_sql, row_limit=RESULT_ROW_LIMIT
+        )
+        lakebase_cache_write(
+            config,
+            question=question,
+            sql=genie_result.generated_sql,
+            response_text=genie_result.response_text or "",
+            cache_scope=GLOBAL_SCOPE,
+            embedding=lookup.embedding,
+            validated=True,
+            validation_source="genie",
+        )
         latency = time.time() - t0
-        print(f"  HIT ({hit_type}, score={score:.3f}) in {latency:.3f}s")
+        print(f"  SQL: {genie_result.generated_sql[:160]}...")
+        print_sql_preview(sql_result)
+        print(f"  Written to Lakebase cache (total: {latency:.1f}s)")
+
         results.append({
             "question": question[:50],
-            "cold_s": latency,
+            "first_s": latency,
             "warm_s": None,
-            "speedup": "-",
+            "source": "genie",
+            "speedup": None,
         })
-        continue
-
-    # --- Cache miss → Genie API ---
-    print("  MISS → calling Genie API with retry/backoff...")
-    genie_result = call_genie_with_retry(config, question)
-    print(f"  Genie returned in {genie_result.latency_seconds:.1f}s")
-    if genie_result.generated_sql:
-        print(f"  SQL: {genie_result.generated_sql[:120]}...")
-
-    # --- Cache write (reuse embedding from lookup to avoid duplicate API call) ---
-    lakebase_cache_write(
-        config, question,
-        genie_result.generated_sql or "",
-        genie_result.response_text or "",
-        embedding=embedding,
-    )
-    cold_latency = time.time() - t0
-    print(f"  Written to Lakebase cache (total: {cold_latency:.1f}s)")
-
-    results.append({
-        "question": question[:50],
-        "cold_s": cold_latency,
-        "warm_s": None,
-        "speedup": None,
-    })
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Demo — Warm Pass (Cache Hit)
+# MAGIC ## Demo — Warm Pass
 # MAGIC
-# MAGIC Same questions again — all should return from cache (exact match).
+# MAGIC Same questions again. Cache hits still re-execute cached SQL; the cache saves
+# MAGIC Genie latency, not SQL execution or authorization.
 
 # COMMAND ----------
 
 for i, question in enumerate(demo_questions):
-    print(f"\n{'=' * 60}")
-    print(f"Question: {question}")
+    with trace_operation(config, "scenario1_warm_question", "CHAIN", {"question": question}):
+        print(f"\n{'=' * 60}")
+        print(f"Question: {question}")
 
-    t0 = time.time()
-    hit_type, cached_sql, cached_resp, score, _ = lakebase_cache_lookup(
-        config, question, threshold=SIMILARITY_THRESHOLD
-    )
-    warm_latency = time.time() - t0
+        t0 = time.time()
+        lookup = lakebase_cache_lookup(
+            config,
+            question,
+            threshold=SIMILARITY_THRESHOLD,
+            cache_scope=GLOBAL_SCOPE,
+        )
 
-    if hit_type:
-        print(f"  HIT ({hit_type}, score={score:.3f}) in {warm_latency:.3f}s")
-        if cached_sql:
-            print(f"  Cached SQL: {cached_sql[:120]}...")
-    else:
-        print("  Unexpected MISS")
-        warm_latency = None
+        if lookup.hit:
+            sql_result = execute_cached_sql_with_trace(
+                config, lookup.generated_sql, row_limit=RESULT_ROW_LIMIT
+            )
+            warm_latency = time.time() - t0
+            print(f"  HIT ({lookup.hit_type}, score={lookup.score:.3f}) in {warm_latency:.3f}s")
+            print(f"  Cached SQL: {lookup.generated_sql[:160]}...")
+            print_sql_preview(sql_result)
+        else:
+            print("  Unexpected MISS")
+            warm_latency = None
 
-    if i < len(results):
-        results[i]["warm_s"] = warm_latency
-        if warm_latency and results[i]["cold_s"]:
-            results[i]["speedup"] = f"{results[i]['cold_s'] / warm_latency:.0f}x"
+        if i < len(results):
+            results[i]["warm_s"] = warm_latency
+            if warm_latency and results[i]["first_s"]:
+                results[i]["speedup"] = f"{results[i]['first_s'] / warm_latency:.0f}x"
 
 # COMMAND ----------
 
 # MAGIC %md
 # MAGIC ## Demo — Semantic Similarity Hit
-# MAGIC
-# MAGIC Ask a **paraphrased** version of a previously cached question.  The exact-match
-# MAGIC lookup will miss, but the pgvector similarity search should find a match above
-# MAGIC the threshold (≥ 0.92).
 
 # COMMAND ----------
 
 if demo_questions:
-    original = demo_questions[0]
     paraphrased = "How much total deposit volume did we have in 2024?"
-    print(f"Original:    {original}")
+    print(f"Original:    {demo_questions[0]}")
     print(f"Paraphrased: {paraphrased}")
 
     t0 = time.time()
-    hit_type, cached_sql, cached_resp, score, _ = lakebase_cache_lookup(
-        config, paraphrased, threshold=SIMILARITY_THRESHOLD
+    lookup = lakebase_cache_lookup(
+        config,
+        paraphrased,
+        threshold=SIMILARITY_THRESHOLD,
+        cache_scope=GLOBAL_SCOPE,
     )
     latency = time.time() - t0
 
-    if hit_type:
-        print(f"\n  HIT ({hit_type}, score={score:.3f}) in {latency:.3f}s")
-        print("  The paraphrased question matched via vector similarity!")
-        if cached_sql:
-            print(f"  Cached SQL: {cached_sql[:120]}...")
+    if lookup.hit:
+        sql_result = execute_cached_sql_with_trace(
+            config, lookup.generated_sql, row_limit=RESULT_ROW_LIMIT
+        )
+        print(f"\n  HIT ({lookup.hit_type}, score={lookup.score:.3f}) in {latency:.3f}s")
+        print("  The paraphrased question matched via vector similarity.")
+        print_sql_preview(sql_result)
     else:
         print(f"\n  MISS (score below threshold {SIMILARITY_THRESHOLD})")
-        print("  This is expected if the paraphrase differs significantly.")
 
 # COMMAND ----------
 
@@ -183,12 +220,11 @@ if demo_questions:
 # COMMAND ----------
 
 print("\n" + "=" * 80)
-print("SCENARIO 1: Lakebase + pgvector Cache — Results")
+print("SCENARIO 1: Lakebase + pgvector Cache - Results")
 print("=" * 80)
-print_summary_table(results, ["question", "cold_s", "warm_s", "speedup"])
+print_summary_table(results, ["question", "first_s", "warm_s", "source", "speedup"])
 print()
-print("Cache hit latency is dominated by the Lakebase round-trip (~50-200ms),")
-print("vs. Genie API latency (~5-30s).  Expect 50-500x speedup on cache hits.")
+print("Cache hits avoid Genie latency but still execute SQL for freshness and access control.")
 
 # COMMAND ----------
 

--- a/aibi/genie-query-caching/2_vector_search_cache.py
+++ b/aibi/genie-query-caching/2_vector_search_cache.py
@@ -4,20 +4,15 @@
 # MAGIC
 # MAGIC ![Architecture](scenario2-vector-search.png)
 # MAGIC
-# MAGIC This notebook demonstrates query caching using a **Databricks Vector Search**
-# MAGIC index backed by a Delta table in Unity Catalog.
+# MAGIC This notebook demonstrates a Databricks Vector Search cache backed by Delta.
+# MAGIC Cache hits retrieve generated SQL, then re-execute that SQL under the current
+# MAGIC Databricks identity.
 # MAGIC
 # MAGIC **Cache flow:**
-# MAGIC 1. **Hybrid search** (semantic + BM25) against the VS index with managed embeddings
-# MAGIC 2. **Confidence tiering** on the returned similarity score:
-# MAGIC    - ≥ 0.90 → **auto-execute** the cached SQL
-# MAGIC    - 0.75–0.90 → **confirm** — return cached result but flag for user review
-# MAGIC    - < 0.75 → **fall through** to Genie API
-# MAGIC 3. **MISS** → call Genie API (with retry + backoff)
-# MAGIC 4. **APPEND** result to Delta table `cache_store`, trigger VS index sync
-# MAGIC
-# MAGIC **Key properties:** Unity Catalog governed, hybrid semantic + BM25 search,
-# MAGIC managed embeddings (no manual embedding generation needed).
+# MAGIC 1. Hybrid search (semantic + BM25) against the Vector Search index.
+# MAGIC 2. Confidence tiering on the returned score.
+# MAGIC 3. On a hit, increment hit metadata and re-execute cached SQL.
+# MAGIC 4. On a miss, call Genie, execute the generated SQL, upsert it to Delta, and sync.
 # MAGIC
 # MAGIC **Prerequisites:** Run `0_setup.py` first.
 
@@ -38,22 +33,29 @@ import time
 from databricks.vector_search.client import VectorSearchClient
 
 from utils import (
+    CacheLookupResult,
+    GLOBAL_SCOPE,
+    build_cache_context,
     call_genie_with_retry,
-    generate_id,
+    delta_cache_upsert,
+    delta_increment_hit_count,
+    execute_cached_sql_with_trace,
     load_config,
-    normalize_question,
+    print_sql_preview,
     print_summary_table,
     sync_vs_index_and_wait,
-    utcnow,
+    table_name,
+    trace_operation,
+    vector_search_filters,
 )
 
 config = load_config("./configs.yaml")
+context = build_cache_context(config)
 
-CATALOG = config["catalog"]
-SCHEMA = config["schema"]
 VS_ENDPOINT = config["vs_endpoint"]
-CACHE_STORE_TABLE = f"{CATALOG}.{SCHEMA}.cache_store"
-CACHE_STORE_INDEX = f"{CATALOG}.{SCHEMA}.cache_store_index"
+CACHE_STORE_TABLE = table_name(config, "cache_store")
+CACHE_STORE_INDEX = f"{config['catalog']}.{config['schema']}.cache_store_index"
+RESULT_ROW_LIMIT = int(config.get("result_row_limit", 100))
 
 thresholds = config.get("thresholds", {})
 AUTO_THRESHOLD = thresholds.get("vs_auto_execute", 0.90)
@@ -62,8 +64,10 @@ CONFIRM_THRESHOLD = thresholds.get("vs_confirm", 0.75)
 vsc = VectorSearchClient(disable_notice=True)
 
 print(f"VS Index:           {CACHE_STORE_INDEX}")
+print(f"Cache context key:  {context.cache_context_key}")
 print(f"Auto threshold:     {AUTO_THRESHOLD}")
 print(f"Confirm threshold:  {CONFIRM_THRESHOLD}")
+print(f"Result row limit:   {RESULT_ROW_LIMIT}")
 
 # COMMAND ----------
 
@@ -77,86 +81,49 @@ def cache_lookup_vs(
     question: str,
     auto_threshold: float = AUTO_THRESHOLD,
     confirm_threshold: float = CONFIRM_THRESHOLD,
-):
-    """Search the Vector Search index for a cached response.
-
-    Uses hybrid (semantic + BM25) search with managed embeddings.
-
-    Returns (tier, cached_sql, cached_response, score) where tier is:
-    - "auto"    — score ≥ auto_threshold, safe to execute cached SQL directly
-    - "confirm" — score between confirm and auto thresholds, flag for review
-    - None      — no match above confirm threshold (cache miss)
-    """
-    index = vsc.get_index(endpoint_name=VS_ENDPOINT, index_name=CACHE_STORE_INDEX)
-
-    results = index.similarity_search(
-        query_text=question,
-        columns=["id", "question_text", "cached_sql", "cached_response"],
-        num_results=1,
-        query_type="HYBRID",
-    )
+) -> CacheLookupResult:
+    """Search the Vector Search index for a validated cache entry."""
+    with trace_operation(config, "vector_search_cache_lookup", "RETRIEVER", {"question": question}):
+        index = vsc.get_index(endpoint_name=VS_ENDPOINT, index_name=CACHE_STORE_INDEX)
+        results = index.similarity_search(
+            query_text=question,
+            columns=["id", "question_text", "generated_sql", "genie_response_text"],
+            filters=vector_search_filters(config, cache_scope=GLOBAL_SCOPE, validated_only=True),
+            num_results=1,
+            query_type="HYBRID",
+        )
 
     hits = results.get("result", {}).get("data_array", [])
     if not hits:
-        return None, None, None, 0.0
+        return CacheLookupResult(hit_type=None, score=0.0)
 
     row = hits[0]
-    # VS returns: [id, question_text, cached_sql, cached_response, score]
     score = float(row[-1]) if row[-1] is not None else 0.0
-    cached_sql = row[2]
-    cached_response = row[3]
-
     if score >= auto_threshold:
-        return "auto", cached_sql, cached_response, score
+        tier = "auto"
     elif score >= confirm_threshold:
-        return "confirm", cached_sql, cached_response, score
+        tier = "confirm"
     else:
-        return None, None, None, score
+        return CacheLookupResult(hit_type=None, score=score)
 
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## Cache Write — Append to Delta Table
-
-# COMMAND ----------
-
-
-def cache_write_delta(question: str, sql: str, response_text: str):
-    """Append a new entry to the cache_store Delta table.
-
-    The VS index will pick up the new row on the next sync.
-    """
-    from pyspark.sql import Row
-
-    row_id = generate_id()
-    normalized = normalize_question(question)
-
-    new_row = Row(
-        id=row_id,
-        question_text=question,
-        question_normalized=normalized,
-        cached_sql=sql or "",
-        cached_response=response_text or "",
-        created_at=utcnow(),
-        hit_count=0,
+    return CacheLookupResult(
+        hit_type="vector-search",
+        tier=tier,
+        row_id=row[0],
+        question_text=row[1],
+        generated_sql=row[2],
+        genie_response_text=row[3],
+        score=score,
     )
-    df = spark.createDataFrame([new_row])
-    df.write.mode("append").saveAsTable(CACHE_STORE_TABLE)
-
-    print(f"  Written to Delta table {CACHE_STORE_TABLE} (id={row_id})")
-    return row_id
 
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Demo — Cold Pass (Cache Miss → Genie API)
+# MAGIC ## Demo — First Pass
 # MAGIC
-# MAGIC Each question goes through:
-# MAGIC 1. VS hybrid search → expected **MISS** (empty index)
-# MAGIC 2. Genie API call with retry/backoff
-# MAGIC 3. Delta table append → VS index sync
+# MAGIC With `seed_demo_data: false`, each question should miss and call Genie. With
+# MAGIC seeded mode enabled, matching questions may hit immediately.
 
 # COMMAND ----------
 
@@ -167,50 +134,79 @@ demo_questions = config.get("demo_questions", [
 results = []
 
 for question in demo_questions:
-    print(f"\n{'=' * 60}")
-    print(f"Question: {question}")
+    with trace_operation(config, "scenario2_question", "CHAIN", {"question": question}):
+        print(f"\n{'=' * 60}")
+        print(f"Question: {question}")
 
-    # --- Cache lookup ---
-    t0 = time.time()
-    tier, cached_sql, cached_resp, score = cache_lookup_vs(question)
+        t0 = time.time()
+        lookup = cache_lookup_vs(question)
 
-    if tier:
+        if lookup.hit:
+            delta_increment_hit_count(spark, CACHE_STORE_TABLE, lookup.row_id)
+            sql_result = execute_cached_sql_with_trace(
+                config, lookup.generated_sql, row_limit=RESULT_ROW_LIMIT
+            )
+            latency = time.time() - t0
+            print(f"  HIT (tier={lookup.tier}, score={lookup.score:.3f}) in {latency:.3f}s")
+            if lookup.tier == "confirm":
+                print("  Moderate confidence; production UIs should ask for user confirmation.")
+            print(f"  Cached SQL: {lookup.generated_sql[:160]}...")
+            print_sql_preview(sql_result)
+            results.append({
+                "question": question[:50],
+                "first_s": latency,
+                "warm_s": None,
+                "tier": lookup.tier,
+                "source": "vs-hit",
+                "speedup": "-",
+            })
+            continue
+
+        print(f"  MISS (best score={lookup.score:.3f}) -> calling Genie API...")
+        genie_result = call_genie_with_retry(config, question)
+        print(f"  Genie returned in {genie_result.latency_seconds:.1f}s")
+
+        if not genie_result.cacheable:
+            latency = time.time() - t0
+            print("  Genie did not return SQL; not caching this response.")
+            results.append({
+                "question": question[:50],
+                "first_s": latency,
+                "warm_s": None,
+                "tier": "miss",
+                "source": "genie-no-sql",
+                "speedup": None,
+            })
+            continue
+
+        sql_result = execute_cached_sql_with_trace(
+            config, genie_result.generated_sql, row_limit=RESULT_ROW_LIMIT
+        )
+        row_id = delta_cache_upsert(
+            spark,
+            CACHE_STORE_TABLE,
+            config,
+            question=question,
+            sql=genie_result.generated_sql,
+            response_text=genie_result.response_text or "",
+            cache_scope=GLOBAL_SCOPE,
+            validated=True,
+            validation_source="genie",
+        )
         latency = time.time() - t0
-        print(f"  HIT (tier={tier}, score={score:.3f}) in {latency:.3f}s")
+        print(f"  SQL: {genie_result.generated_sql[:160]}...")
+        print_sql_preview(sql_result)
+        print(f"  Upserted Delta cache row id={row_id}")
+
         results.append({
             "question": question[:50],
-            "cold_s": latency,
+            "first_s": latency,
             "warm_s": None,
-            "tier": tier,
-            "speedup": "-",
+            "tier": "miss",
+            "source": "genie",
+            "speedup": None,
         })
-        continue
 
-    print(f"  MISS (best score={score:.3f}) → calling Genie API...")
-
-    # --- Genie API ---
-    genie_result = call_genie_with_retry(config, question)
-    print(f"  Genie returned in {genie_result.latency_seconds:.1f}s")
-    if genie_result.generated_sql:
-        print(f"  SQL: {genie_result.generated_sql[:120]}...")
-
-    # --- Cache write ---
-    cache_write_delta(
-        question,
-        genie_result.generated_sql or "",
-        genie_result.response_text or "",
-    )
-    cold_latency = time.time() - t0
-
-    results.append({
-        "question": question[:50],
-        "cold_s": cold_latency,
-        "warm_s": None,
-        "tier": "miss",
-        "speedup": None,
-    })
-
-# --- Sync VS index so warm pass can find the new entries ---
 print(f"\n{'=' * 60}")
 print("Syncing VS index for warm pass...")
 sync_vs_index_and_wait(vsc, VS_ENDPOINT, CACHE_STORE_INDEX)
@@ -218,64 +214,65 @@ sync_vs_index_and_wait(vsc, VS_ENDPOINT, CACHE_STORE_INDEX)
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Demo — Warm Pass (Cache Hit with Confidence Tiering)
-# MAGIC
-# MAGIC Same questions — should now return from VS cache with **auto** tier.
+# MAGIC ## Demo — Warm Pass
 
 # COMMAND ----------
 
 for i, question in enumerate(demo_questions):
-    print(f"\n{'=' * 60}")
-    print(f"Question: {question}")
+    with trace_operation(config, "scenario2_warm_question", "CHAIN", {"question": question}):
+        print(f"\n{'=' * 60}")
+        print(f"Question: {question}")
 
-    t0 = time.time()
-    tier, cached_sql, cached_resp, score = cache_lookup_vs(question)
-    warm_latency = time.time() - t0
+        t0 = time.time()
+        lookup = cache_lookup_vs(question)
 
-    if tier:
-        print(f"  HIT (tier={tier}, score={score:.3f}) in {warm_latency:.3f}s")
-        if tier == "confirm":
-            print("  Confidence is moderate — a production system would ask the user to confirm")
-        if cached_sql:
-            print(f"  Cached SQL: {cached_sql[:120]}...")
-    else:
-        print(f"  Unexpected MISS (score={score:.3f})")
-        warm_latency = None
+        if lookup.hit:
+            delta_increment_hit_count(spark, CACHE_STORE_TABLE, lookup.row_id)
+            sql_result = execute_cached_sql_with_trace(
+                config, lookup.generated_sql, row_limit=RESULT_ROW_LIMIT
+            )
+            warm_latency = time.time() - t0
+            print(f"  HIT (tier={lookup.tier}, score={lookup.score:.3f}) in {warm_latency:.3f}s")
+            if lookup.tier == "confirm":
+                print("  Moderate confidence; production UIs should ask for user confirmation.")
+            print(f"  Cached SQL: {lookup.generated_sql[:160]}...")
+            print_sql_preview(sql_result)
+        else:
+            print(f"  Unexpected MISS (score={lookup.score:.3f})")
+            warm_latency = None
 
-    if i < len(results):
-        results[i]["warm_s"] = warm_latency
-        results[i]["tier"] = tier or "miss"
-        if warm_latency and results[i]["cold_s"]:
-            results[i]["speedup"] = f"{results[i]['cold_s'] / warm_latency:.0f}x"
+        if i < len(results):
+            results[i]["warm_s"] = warm_latency
+            results[i]["tier"] = lookup.tier or "miss"
+            if warm_latency and results[i]["first_s"]:
+                results[i]["speedup"] = f"{results[i]['first_s'] / warm_latency:.0f}x"
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Demo — Confidence Tiering with Paraphrased Question
-# MAGIC
-# MAGIC A paraphrased version of a cached question may score between the confirm and
-# MAGIC auto thresholds, demonstrating the three-tier system.
+# MAGIC ## Demo — Confidence Tiering with a Paraphrased Question
 
 # COMMAND ----------
 
 if demo_questions:
-    original = demo_questions[0]
     paraphrased = "How much total deposit volume did we have in 2024?"
-    print(f"Original:    {original}")
+    print(f"Original:    {demo_questions[0]}")
     print(f"Paraphrased: {paraphrased}")
 
     t0 = time.time()
-    tier, cached_sql, cached_resp, score = cache_lookup_vs(paraphrased)
-    latency = time.time() - t0
+    lookup = cache_lookup_vs(paraphrased)
 
-    if tier == "auto":
-        print(f"\n  AUTO tier (score={score:.3f}) in {latency:.3f}s")
-        print("  High confidence — safe to execute cached SQL directly")
-    elif tier == "confirm":
-        print(f"\n  CONFIRM tier (score={score:.3f}) in {latency:.3f}s")
-        print("  Moderate confidence — production system would ask user to review")
+    if lookup.hit:
+        delta_increment_hit_count(spark, CACHE_STORE_TABLE, lookup.row_id)
+        sql_result = execute_cached_sql_with_trace(
+            config, lookup.generated_sql, row_limit=RESULT_ROW_LIMIT
+        )
+        latency = time.time() - t0
+        print(f"\n  HIT tier={lookup.tier} (score={lookup.score:.3f}) in {latency:.3f}s")
+        print_sql_preview(sql_result)
     else:
-        print(f"\n  MISS (score={score:.3f}) in {latency:.3f}s")
+        latency = time.time() - t0
+        print(f"\n  MISS (score={lookup.score:.3f}) in {latency:.3f}s")
         print(f"  Below confirm threshold ({CONFIRM_THRESHOLD})")
 
 # COMMAND ----------
@@ -286,13 +283,12 @@ if demo_questions:
 # COMMAND ----------
 
 print("\n" + "=" * 80)
-print("SCENARIO 2: Vector Search Cache — Results")
+print("SCENARIO 2: Vector Search Cache - Results")
 print("=" * 80)
-print_summary_table(results, ["question", "cold_s", "warm_s", "tier", "speedup"])
+print_summary_table(results, ["question", "first_s", "warm_s", "tier", "source", "speedup"])
 print()
-print("Note: Cold latency includes Genie API time + Delta write + VS index sync.")
-print("In production, continuous sync eliminates the sync wait (~10-30s).")
-print("Cache hit latency is ~200-500ms (VS round-trip + managed embedding).")
+print("Cache hits avoid Genie latency but still execute SQL for freshness and access control.")
+print("Triggered VS sync is for demo reproducibility; production can use continuous sync.")
 
 # COMMAND ----------
 

--- a/aibi/genie-query-caching/3_hybrid_cache.py
+++ b/aibi/genie-query-caching/3_hybrid_cache.py
@@ -1,23 +1,23 @@
 # Databricks notebook source
 # MAGIC %md
-# MAGIC # Scenario 3: Hybrid Cache — L1 Lakebase + L2 Vector Search (Recommended)
+# MAGIC # Scenario 3: Hybrid Cache — L1 Lakebase + L2 Vector Search
 # MAGIC
 # MAGIC ![Architecture](scenario3-hybrid.png)
 # MAGIC
-# MAGIC This notebook demonstrates the **recommended** two-tier caching architecture:
+# MAGIC This notebook demonstrates a two-tier cache:
 # MAGIC
-# MAGIC | Layer | Technology | Purpose | TTL |
-# MAGIC |-------|-----------|---------|-----|
-# MAGIC | **L1** | Lakebase + pgvector | Session cache — fast exact + vector match | Session lifetime |
-# MAGIC | **L2** | Vector Search + Delta | Knowledge base — validated, durable cache | 30+ weeks |
+# MAGIC | Layer | Technology | Purpose |
+# MAGIC |-------|-----------|---------|
+# MAGIC | L1 | Lakebase + pgvector | Session-scoped cache for the current workflow |
+# MAGIC | L2 | Vector Search + Delta | Validated cross-session SQL knowledge base |
 # MAGIC
 # MAGIC **Cache flow:**
-# MAGIC 1. **L1 check** — exact match + pgvector similarity (threshold ≥ 0.93) in Lakebase
-# MAGIC 2. **L1 HIT** → return cached response immediately
-# MAGIC 3. **L1 MISS → L2 check** — hybrid semantic + BM25 search (threshold ≥ 0.90)
-# MAGIC 4. **L2 HIT** → re-execute cached SQL for freshness, promote to L1
-# MAGIC 5. **L2 MISS** → Genie API (with retry + backoff) → write to L1
-# MAGIC 6. **Promotion** — entries promoted from L1 → L2 after validation (thumbs-up or hit_count ≥ 3)
+# MAGIC 1. Check L1 for a session-scoped exact/vector match.
+# MAGIC 2. On L1 hit, re-execute cached SQL.
+# MAGIC 3. On L1 miss, check validated L2 rows for the current cache context.
+# MAGIC 4. On L2 hit, re-execute cached SQL and promote it to L1.
+# MAGIC 5. On L2 miss, call Genie, execute generated SQL, and write it to L1.
+# MAGIC 6. Simulate validation by promoting selected L1 entries to L2.
 # MAGIC
 # MAGIC **Prerequisites:** Run `0_setup.py` first.
 
@@ -33,63 +33,76 @@
 
 # COMMAND ----------
 
-import json
 import time
 import uuid
 
 from databricks.vector_search.client import VectorSearchClient
 
 from utils import (
+    CacheLookupResult,
+    GLOBAL_SCOPE,
+    SESSION_SCOPE,
+    build_cache_context,
     call_genie_with_retry,
-    generate_id,
+    delta_cache_upsert,
+    delta_increment_hit_count,
+    execute_cached_sql_with_trace,
     get_lakebase_connection,
     lakebase_cache_lookup,
     lakebase_cache_write,
     load_config,
-    normalize_question,
+    print_sql_preview,
     print_summary_table,
     sync_vs_index_and_wait,
-    utcnow,
+    table_name,
+    trace_operation,
+    vector_search_filters,
 )
 
 config = load_config("./configs.yaml")
+context = build_cache_context(config)
 
-CATALOG = config["catalog"]
-SCHEMA = config["schema"]
 VS_ENDPOINT = config["vs_endpoint"]
-CACHE_KB_TABLE = f"{CATALOG}.{SCHEMA}.cache_knowledge_base"
-CACHE_KB_INDEX = f"{CATALOG}.{SCHEMA}.cache_knowledge_base_index"
+CACHE_KB_TABLE = table_name(config, "cache_knowledge_base")
+CACHE_KB_INDEX = f"{config['catalog']}.{config['schema']}.cache_knowledge_base_index"
+RESULT_ROW_LIMIT = int(config.get("result_row_limit", 100))
 
 thresholds = config.get("thresholds", {})
 L1_THRESHOLD = thresholds.get("lakebase_hybrid", 0.93)
 L2_THRESHOLD = thresholds.get("vs_auto_execute", 0.90)
 
-# Unique session ID for this notebook run — scopes L1 cache entries
 SESSION_ID = uuid.uuid4().hex[:8]
-
 vsc = VectorSearchClient(disable_notice=True)
 
 print(f"Session ID:         {SESSION_ID}")
+print(f"Cache context key:  {context.cache_context_key}")
 print(f"L1 threshold:       {L1_THRESHOLD} (Lakebase pgvector)")
 print(f"L2 threshold:       {L2_THRESHOLD} (Vector Search)")
+print(f"Result row limit:   {RESULT_ROW_LIMIT}")
 print(f"L2 Knowledge Base:  {CACHE_KB_INDEX}")
 
 # COMMAND ----------
 
 # MAGIC %md
 # MAGIC ## L1 — Lakebase Session Cache
-# MAGIC
-# MAGIC Uses shared `lakebase_cache_lookup` / `lakebase_cache_write` from `utils.py`
-# MAGIC with a `session_id` to scope entries to this notebook run.
 
 # COMMAND ----------
 
 
 def l1_clear_session(session_id: str = SESSION_ID):
-    """Delete all L1 cache entries for a specific session."""
+    """Delete all L1 cache entries for a specific session and context."""
     conn = get_lakebase_connection(config)
     with conn.cursor() as cur:
-        cur.execute("DELETE FROM genie_cache WHERE session_id = %s", (session_id,))
+        cur.execute(
+            """
+            DELETE FROM genie_cache
+            WHERE space_id = %s
+              AND cache_context_key = %s
+              AND cache_scope = %s
+              AND session_id = %s
+            """,
+            (context.space_id, context.cache_context_key, SESSION_SCOPE, session_id),
+        )
     conn.commit()
     print(f"  Cleared L1 cache for session {session_id}")
 
@@ -102,53 +115,51 @@ def l1_clear_session(session_id: str = SESSION_ID):
 # COMMAND ----------
 
 
-def l2_cache_lookup(question: str):
-    """L2 cache lookup: hybrid semantic + BM25 search on the knowledge base VS index."""
-    index = vsc.get_index(endpoint_name=VS_ENDPOINT, index_name=CACHE_KB_INDEX)
-
-    results = index.similarity_search(
-        query_text=question,
-        columns=["id", "question_text", "cached_sql", "cached_response"],
-        num_results=1,
-        query_type="HYBRID",
-    )
+def l2_cache_lookup(question: str) -> CacheLookupResult:
+    """Lookup a validated L2 cache entry for the current context."""
+    with trace_operation(config, "l2_vector_search_lookup", "RETRIEVER", {"question": question}):
+        index = vsc.get_index(endpoint_name=VS_ENDPOINT, index_name=CACHE_KB_INDEX)
+        results = index.similarity_search(
+            query_text=question,
+            columns=["id", "question_text", "generated_sql", "genie_response_text"],
+            filters=vector_search_filters(config, cache_scope=GLOBAL_SCOPE, validated_only=True),
+            num_results=1,
+            query_type="HYBRID",
+        )
 
     hits = results.get("result", {}).get("data_array", [])
     if not hits:
-        return None, None, None, 0.0
+        return CacheLookupResult(hit_type=None, score=0.0)
 
     row = hits[0]
     score = float(row[-1]) if row[-1] is not None else 0.0
-    cached_sql = row[2]
-    cached_response = row[3]
+    if score < L2_THRESHOLD:
+        return CacheLookupResult(hit_type=None, score=score)
 
-    if score >= L2_THRESHOLD:
-        return "hit", cached_sql, cached_response, score
+    return CacheLookupResult(
+        hit_type="l2",
+        tier="auto",
+        row_id=row[0],
+        question_text=row[1],
+        generated_sql=row[2],
+        genie_response_text=row[3],
+        score=score,
+    )
 
-    return None, None, None, score
 
-
-def promote_to_l2(question: str, sql: str, response_text: str, source: str = "auto"):
-    """Promote a validated entry from L1 to the L2 knowledge base (Delta table)."""
-    from pyspark.sql import Row
-
-    row_id = generate_id()
-    normalized = normalize_question(question)
-
-    new_row = Row(
-        id=row_id,
-        question_text=question,
-        question_normalized=normalized,
-        cached_sql=sql or "",
-        cached_response=response_text or "",
+def promote_to_l2(question: str, sql: str, response_text: str = "", source: str = "manual-validation"):
+    """Promote validated SQL into the durable L2 knowledge base."""
+    row_id = delta_cache_upsert(
+        spark,
+        CACHE_KB_TABLE,
+        config,
+        question=question,
+        sql=sql,
+        response_text=response_text or "",
+        cache_scope=GLOBAL_SCOPE,
         validated=True,
         validation_source=source,
-        created_at=utcnow(),
-        hit_count=0,
     )
-    df = spark.createDataFrame([new_row])
-    df.write.mode("append").saveAsTable(CACHE_KB_TABLE)
-
     print(f"  Promoted to L2 knowledge base (id={row_id}, source={source})")
     return row_id
 
@@ -162,67 +173,104 @@ def promote_to_l2(question: str, sql: str, response_text: str, source: str = "au
 
 
 def query_with_hybrid_cache(question: str, session_id: str = SESSION_ID):
-    """Execute the full hybrid cache flow: L1 → L2 → Genie API.
+    """Run L1 -> L2 -> Genie and always execute SQL for the final answer."""
+    with trace_operation(
+        config,
+        "query_with_hybrid_cache",
+        "CHAIN",
+        {"question": question, "session_id": session_id},
+    ):
+        start = time.time()
 
-    Returns a dict with: source, sql, response, score, latency_s
-    """
-    start = time.time()
-
-    # --- L1: Lakebase session cache ---
-    hit_type, sql, resp, score, embedding = lakebase_cache_lookup(
-        config, question, threshold=L1_THRESHOLD, session_id=session_id,
-    )
-    if hit_type:
-        return {
-            "source": f"L1-{hit_type}",
-            "sql": sql,
-            "response": resp,
-            "score": score,
-            "latency_s": time.time() - start,
-        }
-
-    # --- L2: Vector Search knowledge base ---
-    hit, sql, resp_text, score = l2_cache_lookup(question)
-    if hit:
-        # Promote L2 hit to L1 for session-level caching (reuse embedding from L1 lookup)
-        lakebase_cache_write(
-            config, question, sql, resp_text or "",
-            session_id=session_id, embedding=embedding,
+        l1 = lakebase_cache_lookup(
+            config,
+            question,
+            threshold=L1_THRESHOLD,
+            cache_scope=SESSION_SCOPE,
+            session_id=session_id,
         )
+        if l1.hit:
+            sql_result = execute_cached_sql_with_trace(
+                config, l1.generated_sql, row_limit=RESULT_ROW_LIMIT
+            )
+            return {
+                "source": f"L1-{l1.hit_type}",
+                "sql": l1.generated_sql,
+                "response": l1.genie_response_text,
+                "score": l1.score,
+                "sql_result": sql_result,
+                "latency_s": time.time() - start,
+            }
+
+        l2 = l2_cache_lookup(question)
+        if l2.hit:
+            delta_increment_hit_count(spark, CACHE_KB_TABLE, l2.row_id)
+            sql_result = execute_cached_sql_with_trace(
+                config, l2.generated_sql, row_limit=RESULT_ROW_LIMIT
+            )
+            lakebase_cache_write(
+                config,
+                question=question,
+                sql=l2.generated_sql,
+                response_text=l2.genie_response_text or "",
+                cache_scope=SESSION_SCOPE,
+                session_id=session_id,
+                embedding=l1.embedding,
+                validated=True,
+                validation_source="l2-hit",
+            )
+            return {
+                "source": "L2-hit",
+                "sql": l2.generated_sql,
+                "response": l2.genie_response_text,
+                "score": l2.score,
+                "sql_result": sql_result,
+                "latency_s": time.time() - start,
+            }
+
+        genie_result = call_genie_with_retry(config, question)
+        if not genie_result.cacheable:
+            return {
+                "source": "Genie-no-sql",
+                "sql": None,
+                "response": genie_result.response_text,
+                "score": 0.0,
+                "sql_result": None,
+                "latency_s": time.time() - start,
+            }
+
+        sql_result = execute_cached_sql_with_trace(
+            config, genie_result.generated_sql, row_limit=RESULT_ROW_LIMIT
+        )
+        lakebase_cache_write(
+            config,
+            question=question,
+            sql=genie_result.generated_sql,
+            response_text=genie_result.response_text or "",
+            cache_scope=SESSION_SCOPE,
+            session_id=session_id,
+            embedding=l1.embedding,
+            validated=False,
+            validation_source=None,
+        )
+
         return {
-            "source": "L2-hit",
-            "sql": sql,
-            "response": resp_text,
-            "score": score,
+            "source": "Genie",
+            "sql": genie_result.generated_sql,
+            "response": genie_result.response_text,
+            "score": 0.0,
+            "sql_result": sql_result,
             "latency_s": time.time() - start,
         }
-
-    # --- Genie API (with retry/backoff) ---
-    genie_result = call_genie_with_retry(config, question)
-    sql = genie_result.generated_sql or ""
-    text = genie_result.response_text or ""
-
-    # Write to L1 (reuse embedding from L1 lookup)
-    lakebase_cache_write(
-        config, question, sql, text,
-        session_id=session_id, embedding=embedding,
-    )
-
-    return {
-        "source": "Genie",
-        "sql": sql,
-        "response": text,
-        "score": 0.0,
-        "latency_s": time.time() - start,
-    }
 
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Pass 1 — Cold Start (L1 Miss, L2 Miss → Genie API)
+# MAGIC ## Pass 1 — Cold Start
 # MAGIC
-# MAGIC All questions hit the Genie API and get written to L1.
+# MAGIC With unseeded setup, this path misses L1/L2 and calls Genie. Seeded setup may
+# MAGIC hit L2 immediately.
 
 # COMMAND ----------
 
@@ -230,7 +278,7 @@ demo_questions = config.get("demo_questions", [
     "What is the total revenue for last quarter?",
 ])
 
-all_results = {}  # question -> {pass1, pass2, pass3, pass4}
+all_results = {}
 
 for question in demo_questions:
     print(f"\n{'=' * 60}")
@@ -239,16 +287,16 @@ for question in demo_questions:
     result = query_with_hybrid_cache(question)
     print(f"  Source: {result['source']} | Latency: {result['latency_s']:.1f}s")
     if result["sql"]:
-        print(f"  SQL: {result['sql'][:120]}...")
+        print(f"  SQL: {result['sql'][:160]}...")
+    if result["sql_result"]:
+        print_sql_preview(result["sql_result"])
 
     all_results[question] = {"pass1": result}
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Pass 2 — L1 Warm (Session Cache Hit)
-# MAGIC
-# MAGIC Same questions → all should return from L1 (Lakebase exact match).
+# MAGIC ## Pass 2 — L1 Warm
 
 # COMMAND ----------
 
@@ -258,6 +306,8 @@ for question in demo_questions:
 
     result = query_with_hybrid_cache(question)
     print(f"  Source: {result['source']} | Score: {result['score']:.3f} | Latency: {result['latency_s']:.3f}s")
+    if result["sql_result"]:
+        print_sql_preview(result["sql_result"])
 
     all_results[question]["pass2"] = result
 
@@ -266,17 +316,17 @@ for question in demo_questions:
 # MAGIC %md
 # MAGIC ## Promote to L2 — Simulate Validation
 # MAGIC
-# MAGIC In production, entries are promoted to L2 after user validation (thumbs-up) or
-# MAGIC repeated use (hit_count ≥ 3).  Here we simulate this by promoting all cached
-# MAGIC entries.
+# MAGIC Production systems should promote only after explicit user validation or a
+# MAGIC durable quality signal. This demo promotes the SQL produced in Pass 1.
 
 # COMMAND ----------
 
 for question in demo_questions:
     r = all_results[question]["pass1"]
-    resp = r["response"]
-    resp_str = resp if isinstance(resp, str) else json.dumps(resp) if resp else ""
-    promote_to_l2(question, r["sql"] or "", resp_str, source="manual-validation")
+    if r["sql"]:
+        promote_to_l2(question, r["sql"], r["response"] or "", source="manual-validation")
+    else:
+        print(f"  Skipping L2 promotion because no SQL was generated: {question[:60]}")
 
 print("\nSyncing L2 VS index...")
 sync_vs_index_and_wait(vsc, VS_ENDPOINT, CACHE_KB_INDEX)
@@ -285,29 +335,29 @@ sync_vs_index_and_wait(vsc, VS_ENDPOINT, CACHE_KB_INDEX)
 
 # MAGIC %md
 # MAGIC ## Clear L1 — Simulate New Session
-# MAGIC
-# MAGIC Delete the current session's L1 entries to simulate a fresh session.
-# MAGIC L2 entries persist.
 
 # COMMAND ----------
 
 l1_clear_session(SESSION_ID)
 
-# Verify L1 is empty for these questions
 for question in demo_questions:
-    hit_type, _, _, _, _ = lakebase_cache_lookup(
-        config, question, threshold=L1_THRESHOLD, session_id=SESSION_ID,
+    lookup = lakebase_cache_lookup(
+        config,
+        question,
+        threshold=L1_THRESHOLD,
+        cache_scope=SESSION_SCOPE,
+        session_id=SESSION_ID,
     )
-    status = "MISS" if hit_type is None else f"HIT ({hit_type})"
-    print(f"  L1 check: {status} — {question[:50]}")
+    status = "MISS" if not lookup.hit else f"HIT ({lookup.hit_type})"
+    print(f"  L1 check: {status} - {question[:50]}")
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Pass 3 — L2 Warm (Knowledge Base Hit → Promote to L1)
+# MAGIC ## Pass 3 — L2 Warm
 # MAGIC
-# MAGIC L1 is empty, but L2 has the promoted entries.  Each L2 hit gets promoted
-# MAGIC back to L1 for the rest of the session.
+# MAGIC L1 is empty, but L2 has validated entries. Each L2 hit is executed and then
+# MAGIC promoted back into L1 for the current session.
 
 # COMMAND ----------
 
@@ -317,15 +367,15 @@ for question in demo_questions:
 
     result = query_with_hybrid_cache(question)
     print(f"  Source: {result['source']} | Score: {result['score']:.3f} | Latency: {result['latency_s']:.3f}s")
+    if result["sql_result"]:
+        print_sql_preview(result["sql_result"])
 
     all_results[question]["pass3"] = result
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Pass 4 — L1 Warm Again (Promoted from L2)
-# MAGIC
-# MAGIC The L2 hits were promoted to L1 in Pass 3.  Now they should hit L1 directly.
+# MAGIC ## Pass 4 — L1 Warm Again
 
 # COMMAND ----------
 
@@ -335,6 +385,8 @@ for question in demo_questions:
 
     result = query_with_hybrid_cache(question)
     print(f"  Source: {result['source']} | Score: {result['score']:.3f} | Latency: {result['latency_s']:.3f}s")
+    if result["sql_result"]:
+        print_sql_preview(result["sql_result"])
 
     all_results[question]["pass4"] = result
 
@@ -350,28 +402,21 @@ for question in demo_questions:
     r = all_results[question]
     summary_rows.append({
         "question": question[:40],
-        "pass1_genie_s": r["pass1"]["latency_s"],
+        "pass1_s": r["pass1"]["latency_s"],
         "pass2_L1_s": r["pass2"]["latency_s"],
         "pass3_L2_s": r.get("pass3", {}).get("latency_s", 0),
         "pass4_L1_s": r.get("pass4", {}).get("latency_s", 0),
     })
 
 print("\n" + "=" * 90)
-print("SCENARIO 3: Hybrid Cache (L1 Lakebase + L2 Vector Search) — Results")
+print("SCENARIO 3: Hybrid Cache (L1 Lakebase + L2 Vector Search) - Results")
 print("=" * 90)
 print_summary_table(
     summary_rows,
-    ["question", "pass1_genie_s", "pass2_L1_s", "pass3_L2_s", "pass4_L1_s"],
+    ["question", "pass1_s", "pass2_L1_s", "pass3_L2_s", "pass4_L1_s"],
 )
 print()
-print("Pass 1: Cold — Genie API (5-30s)")
-print("Pass 2: L1 warm — Lakebase exact match (~50-200ms)")
-print("Pass 3: L2 warm — VS hybrid search + promote to L1 (~0.5-2s)")
-print("Pass 4: L1 warm — promoted entries now in L1 (~50-200ms)")
-print()
-print("The hybrid approach gives you the best of both worlds:")
-print("  - L1 (Lakebase): Blazing fast session cache with ACID writes")
-print("  - L2 (Vector Search): Durable knowledge base that persists across sessions")
+print("The cache avoids Genie latency. Every hit still executes SQL for freshness and access control.")
 
 # COMMAND ----------
 

--- a/aibi/genie-query-caching/README.md
+++ b/aibi/genie-query-caching/README.md
@@ -1,16 +1,17 @@
 # Genie Query Caching
 
-> **WIP — This project is a work in progress and not ready for use.**
-
-Demonstrates three caching strategies for Databricks Genie API responses, reducing latency and API load by serving repeated or semantically similar questions from cache.
+Demonstrates three cache strategies for Databricks Genie responses. The cache
+stores generated SQL and metadata; on every cache hit the notebook re-executes
+the cached SQL under the current Databricks identity for freshness and access
+control.
 
 ## Scenarios
 
 | Scenario | Cache Layer | Key Benefit |
 |----------|-------------|-------------|
-| 1. Lakebase + pgvector | PostgreSQL with vector similarity | ACID writes, immediate read-after-write, scale-to-zero |
-| 2. Vector Search Index | Delta table + managed embeddings | Unity Catalog governance, hybrid semantic + BM25 search |
-| 3. Hybrid (Recommended) | L1: Lakebase session cache + L2: VS knowledge base | Fast session cache + durable cross-session knowledge base |
+| 1. Lakebase + pgvector | PostgreSQL with vector similarity | ACID writes and immediate read-after-write |
+| 2. Vector Search Index | Delta table + managed embeddings | Unity Catalog governance and hybrid semantic + BM25 search |
+| 3. Hybrid | L1 Lakebase session cache + L2 Vector Search knowledge base | Fast session cache plus validated cross-session reuse |
 
 ## Architecture
 
@@ -20,49 +21,56 @@ Demonstrates three caching strategies for Databricks Genie API responses, reduci
 
 ## Prerequisites
 
-- Databricks workspace with **Genie Spaces** enabled and at least one Genie Space configured
-- **Lakebase** instance with the pgvector extension (Scenarios 1 & 3)
-- A Databricks **secret scope** with Lakebase credentials
-- **Vector Search** endpoint (Scenarios 2 & 3)
-- **Unity Catalog** with a catalog/schema for cache tables
-- Run notebooks on **Serverless** compute or a cluster with network access to Lakebase
+- Databricks workspace with Genie Spaces enabled and at least one Genie Space configured
+- Horizon Bank demo data, or another schema compatible with your Genie space
+- Lakebase instance with the pgvector extension (Scenarios 1 and 3)
+- Databricks secret scope with Lakebase credentials
+- Vector Search endpoint permissions (Scenarios 2 and 3)
+- Unity Catalog catalog/schema for cache tables
+- Serverless compute or a cluster with network access to Lakebase
 
 ## Quick Start
 
-1. Copy `configs.template.yaml` → `configs.yaml` and fill in your values
-2. Run `0_setup.py` to create all infrastructure and seed demo data (5 Horizon Bank entries)
-3. Run any scenario notebook:
-   - `1_lakebase_pgvector_cache.py` — simplest, Lakebase-only
-   - `2_vector_search_cache.py` — Vector Search with confidence tiering
-   - `3_hybrid_cache.py` — recommended two-tier approach
+1. Copy `configs.template.yaml` to `configs.yaml` and fill in your values.
+2. Set `data_schema` and `cache_version`; set `data_catalog` if the data lives outside the cache catalog.
+3. Keep `seed_demo_data: false` if you want to exercise the cold miss path.
+4. Run `0_setup.py` to create the cache schema, Lakebase table, Vector Search endpoint, and indexes.
+5. Run a scenario notebook:
+   - `1_lakebase_pgvector_cache.py`
+   - `2_vector_search_cache.py`
+   - `3_hybrid_cache.py`
+
+Set `seed_demo_data: true` only when you want setup to pre-populate demo entries
+so the notebooks start with cache hits.
+
+## Cache Safety Model
+
+- Cache keys include the Genie space ID, configured data catalog/schema, and `cache_version`.
+- Bump `cache_version` whenever Genie instructions, table schemas, metric views, or other semantic definitions change.
+- Cache hits return cached SQL only after re-executing it with Spark SQL under the current Databricks identity.
+- Text-only Genie responses are not cached because they cannot be refreshed or permission-checked.
+- Scenario 3 uses `cache_scope=session` for L1 and `cache_scope=global` for validated L2 entries, so sessions do not overwrite each other.
 
 ## Notebooks
 
 | File | Purpose |
 |------|---------|
-| `0_setup.py` | Create catalog, schema, Lakebase tables with pgvector, Delta tables, VS endpoint/indexes, and seed demo data |
-| `1_lakebase_pgvector_cache.py` | Scenario 1: exact match + pgvector similarity (≥ 0.92) |
-| `2_vector_search_cache.py` | Scenario 2: hybrid semantic + BM25 with 3-tier confidence scoring |
-| `3_hybrid_cache.py` | Scenario 3: L1 Lakebase session cache + L2 VS knowledge base with promotion |
-| `utils.py` | Shared helpers: retry/backoff, Genie API wrapper, embeddings, Lakebase connectivity |
+| `0_setup.py` | Create v2 cache tables, Lakebase pgvector table, Vector Search endpoint/indexes, and optional seed data |
+| `1_lakebase_pgvector_cache.py` | Scenario 1: exact match + pgvector similarity |
+| `2_vector_search_cache.py` | Scenario 2: Vector Search with confidence tiering |
+| `3_hybrid_cache.py` | Scenario 3: session L1 + validated durable L2 |
+| `utils.py` | Shared helpers for config validation, cache IDs, Genie calls, SQL execution, tracing, and cache writes |
 
-## Configuration
+## Schema Changes
 
-See `configs.template.yaml` for all settings:
+This example uses a v2 cache schema. If setup finds old v1 tables, it fails with
+a reset/migration message instead of silently using incompatible tables. For a
+demo reset, drop the old Delta cache tables, delete the old Vector Search
+indexes, and drop the Lakebase `genie_cache` table, then rerun `0_setup.py`.
 
-- **Unity Catalog** — catalog and schema for cache tables
-- **Genie Space** — space ID and timeout
-- **Lakebase** — host, port, database, secret scope/keys
-- **Vector Search** — endpoint name, embedding model
-- **Retry/backoff** — max attempts, base/max delay (decorrelated jitter)
-- **Thresholds** — similarity thresholds for each cache layer
-- **Demo questions** — sample questions used across all notebooks
+## Optional MLflow Tracing
 
-## Key Design Decisions
-
-- **Retry strategy**: Decorrelated jitter (`delay = min(max_delay, uniform(base_delay, prev_delay * 3))`) — avoids thundering herd while providing fast initial retries
-- **Genie API approach**: Uses the [Databricks Python SDK](https://docs.databricks.com/aws/en/genie/conversation-api) (`start_conversation_and_wait`) rather than the REST API (requires manual polling) or [Managed MCP](https://docs.databricks.com/aws/en/generative-ai/mcp/managed-mcp) (designed for AI agent tool use, not programmatic caching where structured response parsing is required)
-- **Embedding model**: [`databricks-qwen3-embedding-0-6b`](https://www.databricks.com/blog/sota-embedding-model-agentic-workflows-now-public-preview) (1024 dimensions, configurable via Matryoshka) via Foundation Model API for Lakebase pgvector; managed embeddings for Vector Search. Supports optional `instruction` parameter for task-specific retrieval boost (1-5%)
-- **Lakebase connectivity**: `psycopg` (psycopg3) + `pgvector` Python package for native PostgreSQL vector search; credentials via Databricks Secrets
-- **Vector Search**: Delta Sync indexes with managed embeddings and `HYBRID` query type (semantic + BM25)
-- **Code structure**: Shared `utils.py` module imported by all notebooks; each notebook adds scenario-specific cache logic
+Set `mlflow.enable_tracing: true` and configure `MLFLOW_TRACKING_URI` plus
+`MLFLOW_EXPERIMENT_ID` to trace cache lookup, Genie calls, Vector Search lookup,
+SQL execution, and scenario orchestration. Without those environment variables,
+the tracing hooks are no-ops.

--- a/aibi/genie-query-caching/configs.template.yaml
+++ b/aibi/genie-query-caching/configs.template.yaml
@@ -1,9 +1,16 @@
 # Genie Query Caching Configuration
 # Copy this file to configs.yaml and fill in your values before running.
 
-# Unity Catalog
+# Cache storage location in Unity Catalog
 catalog: "your_catalog"                    # TODO
 schema: "genie_cache"                      # TODO
+
+# Data queried by the Genie space. If data_catalog is omitted, the cache catalog
+# is used. Bump cache_version whenever Genie instructions, table schemas, metric
+# views, or other semantic definitions change.
+# data_catalog: "your_data_catalog"
+data_schema: "horizon_bank"
+cache_version: "v1"
 
 # Genie Space
 genie_space_id: "your_genie_space_id"      # TODO - from Genie Space URL
@@ -15,8 +22,8 @@ lakebase:
   port: 5432
   database: "your_database"                # TODO
   secret_scope: "your_scope"               # TODO
-  secret_key_username: "lakebase_username"  # TODO
-  secret_key_password: "lakebase_password"  # TODO
+  secret_key_username: "lakebase_username" # TODO
+  secret_key_password: "lakebase_password" # TODO
 
 # Vector Search (Scenarios 2 & 3)
 vs_endpoint: "genie-cache-vs-endpoint"     # TODO
@@ -24,26 +31,34 @@ vs_endpoint: "genie-cache-vs-endpoint"     # TODO
 # Embedding model (Foundation Model API, used for Lakebase pgvector)
 embedding_model: "databricks-qwen3-embedding-0-6b"
 embedding_dimension: 1024
-# Optional: task-specific instruction for improved retrieval accuracy (1-5% boost).
-# Only used by models that support the instruction parameter (e.g., Qwen3).
 embedding_instruction: "Represent this question for finding semantically similar questions:"
+
+# SQL preview limit when cached SQL is re-executed on a hit
+result_row_limit: 100
+
+# Setup behavior. Keep false to exercise cold misses in the scenario notebooks.
+seed_demo_data: false
+
+# Optional MLflow tracing. Tracing is attempted only when this is true AND
+# MLFLOW_TRACKING_URI and MLFLOW_EXPERIMENT_ID are set in the environment.
+mlflow:
+  enable_tracing: false
+  debug: false
 
 # Retry / backoff for Genie API calls
 retry:
   max_attempts: 5
-  base_delay: 1.0      # seconds
+  base_delay: 1.0       # seconds
   max_delay: 60.0       # seconds
 
 # Cache similarity thresholds
 thresholds:
   lakebase_similarity: 0.92       # Scenario 1 - pgvector cosine similarity
-  lakebase_hybrid: 0.93           # Scenario 3 - L1 pgvector threshold (stricter)
-  vs_auto_execute: 0.90           # Scenarios 2 & 3 - auto-execute cached SQL
-  vs_confirm: 0.75                # Scenario 2 - return but flag for user confirmation
+  lakebase_hybrid: 0.93           # Scenario 3 - L1 pgvector threshold
+  vs_auto_execute: 0.90           # Scenarios 2 & 3 - execute cached SQL directly
+  vs_confirm: 0.75                # Scenario 2 - execute but flag for user confirmation
 
 # Demo questions (used across all scenario notebooks)
-# These match the seed data in 0_setup.py — the setup notebook pre-populates
-# the cache so the demo shows HITs on the first pass.
 demo_questions:
   - "What was total deposit volume in 2024?"
   - "Show monthly deposit trend from Jan 2023 to Dec 2025"

--- a/aibi/genie-query-caching/tests/test_utils.py
+++ b/aibi/genie-query-caching/tests/test_utils.py
@@ -1,0 +1,152 @@
+import pathlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+EXAMPLE_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(EXAMPLE_DIR))
+
+import utils  # noqa: E402
+
+
+def _valid_config():
+    return {
+        "catalog": "main",
+        "schema": "genie_cache",
+        "data_catalog": "main",
+        "data_schema": "horizon_bank",
+        "cache_version": "v1",
+        "genie_space_id": "space_123",
+        "genie_timeout_minutes": 5,
+        "vs_endpoint": "genie-cache-vs-endpoint",
+        "embedding_model": "databricks-qwen3-embedding-0-6b",
+        "embedding_dimension": 1024,
+        "result_row_limit": 100,
+        "lakebase": {
+            "host": "lakebase.example.databricks.com",
+            "port": 5432,
+            "database": "cache",
+            "secret_scope": "scope",
+            "secret_key_username": "username",
+            "secret_key_password": "password",
+        },
+        "thresholds": {
+            "lakebase_similarity": 0.92,
+            "lakebase_hybrid": 0.93,
+            "vs_auto_execute": 0.90,
+            "vs_confirm": 0.75,
+        },
+    }
+
+
+def test_load_config_validates_required_values(tmp_path):
+    config_path = tmp_path / "configs.yaml"
+    config_path.write_text(
+        """
+catalog: main
+schema: genie_cache
+data_schema: horizon_bank
+cache_version: v1
+genie_space_id: space_123
+vs_endpoint: genie-cache-vs-endpoint
+lakebase:
+  host: lakebase.example.databricks.com
+  database: cache
+  secret_scope: scope
+  secret_key_username: username
+  secret_key_password: password
+thresholds:
+  vs_auto_execute: 0.90
+  vs_confirm: 0.75
+""",
+        encoding="utf-8",
+    )
+
+    loaded = utils.load_config(str(config_path))
+
+    assert loaded["catalog"] == "main"
+    assert utils.build_cache_context(loaded).data_schema == "horizon_bank"
+
+
+def test_validate_config_rejects_unsafe_uc_identifier():
+    config = _valid_config()
+    config["catalog"] = "main;DROP"
+
+    with pytest.raises(ValueError, match="catalog"):
+        utils.validate_config(config)
+
+
+def test_validate_config_rejects_bad_threshold_ordering():
+    config = _valid_config()
+    config["thresholds"]["vs_confirm"] = 0.95
+    config["thresholds"]["vs_auto_execute"] = 0.90
+
+    with pytest.raises(ValueError, match="vs_confirm"):
+        utils.validate_config(config)
+
+
+def test_normalize_question_removes_punctuation_and_collapses_space():
+    assert utils.normalize_question("  What was revenue?!  ") == "what was revenue"
+    assert utils.normalize_question("A   B\nC") == "a b c"
+
+
+def test_deterministic_cache_id_is_stable_and_session_scoped():
+    config = _valid_config()
+
+    first = utils.deterministic_cache_id(config, "What was revenue?")
+    second = utils.deterministic_cache_id(config, "what was revenue")
+    session_a = utils.deterministic_cache_id(
+        config, "What was revenue?", cache_scope=utils.SESSION_SCOPE, session_id="a"
+    )
+    session_b = utils.deterministic_cache_id(
+        config, "What was revenue?", cache_scope=utils.SESSION_SCOPE, session_id="b"
+    )
+
+    assert first == second
+    assert session_a != session_b
+    assert first != session_a
+    with pytest.raises(ValueError, match="session_id"):
+        utils.deterministic_cache_id(config, "What was revenue?", cache_scope=utils.SESSION_SCOPE)
+
+
+def test_generate_embedding_uses_extra_params(monkeypatch):
+    calls = {}
+
+    class FakeServingEndpoints:
+        def query(self, **kwargs):
+            calls.update(kwargs)
+            return SimpleNamespace(data=[SimpleNamespace(embedding=[0.1, 0.2])])
+
+    fake_client = SimpleNamespace(serving_endpoints=FakeServingEndpoints())
+    monkeypatch.setattr(utils, "_workspace_client", fake_client)
+
+    embedding = utils.generate_embedding(
+        "hello",
+        model="embedding-model",
+        instruction="Represent this question:",
+        dimensions=128,
+    )
+
+    assert embedding == [0.1, 0.2]
+    assert calls == {
+        "name": "embedding-model",
+        "input": ["hello"],
+        "extra_params": {
+            "instruction": "Represent this question:",
+            "dimensions": 128,
+        },
+    }
+
+
+def test_coerce_text_handles_psycopg_jsonb_dicts():
+    assert utils._coerce_text("plain") == "plain"
+    assert utils._coerce_text({"sql": "SELECT 1", "text": "answer"}) == "answer"
+    assert utils._coerce_text(None) is None
+
+
+def test_normalize_cached_sql_rejects_non_read_only_sql():
+    assert utils._normalize_cached_sql(" SELECT 1; ") == "SELECT 1"
+    assert utils._normalize_cached_sql("WITH x AS (SELECT 1) SELECT * FROM x").startswith("WITH")
+    with pytest.raises(ValueError, match="read-only"):
+        utils._normalize_cached_sql("DELETE FROM table")

--- a/aibi/genie-query-caching/utils.py
+++ b/aibi/genie-query-caching/utils.py
@@ -1,25 +1,93 @@
 """
 Shared utilities for Genie Query Caching notebooks.
 
-Provides: config loading, question normalization, embedding generation,
-retry with exponential backoff, Genie API wrapper, Lakebase connectivity,
-cache lookup/write for Lakebase pgvector, and VS index sync.
+The cache stores generated SQL plus metadata. Cache hits re-execute SQL under
+the current Databricks context instead of replaying prior answer text.
 """
 
+from __future__ import annotations
+
+import contextlib
+import hashlib
 import json
+import os
 import random
 import re
 import time
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Any, Optional
 
 import yaml
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.dashboards import MessageStatus
 
 DEFAULT_EMBEDDING_MODEL = "databricks-qwen3-embedding-0-6b"
+DEFAULT_EMBEDDING_DIMENSION = 1024
+DEFAULT_RESULT_ROW_LIMIT = 100
+GLOBAL_SCOPE = "global"
+SESSION_SCOPE = "session"
+_UC_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_ENDPOINT_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class CacheContext:
+    """Stable cache context derived from Genie space and data version."""
+
+    space_id: str
+    data_catalog: str
+    data_schema: str
+    cache_version: str
+    cache_context_key: str
+
+
+@dataclass
+class GenieResult:
+    """Parsed result from a Genie API call."""
+
+    conversation_id: str
+    message_id: str
+    generated_sql: Optional[str] = None
+    response_text: Optional[str] = None
+    latency_seconds: float = 0.0
+
+    @property
+    def cacheable(self) -> bool:
+        return bool(self.generated_sql and self.generated_sql.strip())
+
+
+@dataclass
+class CacheLookupResult:
+    """Result from a cache lookup."""
+
+    hit_type: Optional[str]
+    row_id: Optional[str] = None
+    question_text: Optional[str] = None
+    generated_sql: Optional[str] = None
+    genie_response_text: Optional[str] = None
+    score: float = 0.0
+    embedding: Optional[list[float]] = None
+    tier: Optional[str] = None
+
+    @property
+    def hit(self) -> bool:
+        return self.hit_type is not None
+
+
+@dataclass
+class SqlExecutionResult:
+    """Preview result from executing cached SQL."""
+
+    rows: list[dict[str, Any]]
+    row_count: int
+    truncated: bool
+    latency_seconds: float
 
 
 # ---------------------------------------------------------------------------
@@ -27,25 +95,191 @@ DEFAULT_EMBEDDING_MODEL = "databricks-qwen3-embedding-0-6b"
 # ---------------------------------------------------------------------------
 
 def load_config(path: str = "./configs.yaml") -> dict:
-    """Load YAML configuration file."""
+    """Load and validate YAML configuration."""
     with open(path) as f:
-        return yaml.safe_load(f)
+        config = yaml.safe_load(f) or {}
+    validate_config(config)
+    return config
+
+
+def validate_config(config: dict) -> None:
+    """Fail fast for missing placeholders, unsafe identifiers, and bad thresholds."""
+    required = ["catalog", "schema", "data_schema", "genie_space_id", "vs_endpoint", "cache_version"]
+    missing = [key for key in required if not _has_real_value(config.get(key))]
+    if missing:
+        raise ValueError(f"Missing required config values: {', '.join(missing)}")
+
+    for key in ["catalog", "schema", "data_schema"]:
+        _validate_uc_identifier(config[key], key)
+    if "data_catalog" in config and config["data_catalog"]:
+        _validate_uc_identifier(config["data_catalog"], "data_catalog")
+
+    if not _ENDPOINT_NAME_RE.match(str(config["vs_endpoint"])):
+        raise ValueError("vs_endpoint may only contain letters, numbers, '.', '_', and '-'")
+
+    dim = int(config.get("embedding_dimension", DEFAULT_EMBEDDING_DIMENSION))
+    if dim < 32 or dim > 4096:
+        raise ValueError("embedding_dimension must be between 32 and 4096")
+
+    row_limit = int(config.get("result_row_limit", DEFAULT_RESULT_ROW_LIMIT))
+    if row_limit < 1 or row_limit > 10000:
+        raise ValueError("result_row_limit must be between 1 and 10000")
+
+    thresholds = config.get("thresholds", {})
+    vs_confirm = float(thresholds.get("vs_confirm", 0.75))
+    vs_auto = float(thresholds.get("vs_auto_execute", 0.90))
+    if vs_confirm > vs_auto:
+        raise ValueError("thresholds.vs_confirm must be <= thresholds.vs_auto_execute")
+
+    lakebase = config.get("lakebase", {})
+    for key in ["host", "database", "secret_scope", "secret_key_username", "secret_key_password"]:
+        if not _has_real_value(lakebase.get(key)):
+            raise ValueError(f"Missing required Lakebase config value: lakebase.{key}")
+
+
+def _has_real_value(value: Any) -> bool:
+    if value is None:
+        return False
+    text = str(value).strip()
+    return bool(text) and not text.startswith("your_") and text != "TODO"
+
+
+def _validate_uc_identifier(value: str, field_name: str) -> None:
+    if not _UC_IDENTIFIER_RE.match(str(value)):
+        raise ValueError(
+            f"{field_name} must be a simple Unity Catalog identifier "
+            "(letters, numbers, and underscores only)."
+        )
+
+
+def build_cache_context(config: dict) -> CacheContext:
+    """Build a stable cache context key for a Genie/data semantic version."""
+    space_id = config["genie_space_id"]
+    data_catalog = config.get("data_catalog") or config["catalog"]
+    data_schema = config["data_schema"]
+    cache_version = str(config["cache_version"])
+    raw = "|".join([space_id, data_catalog, data_schema, cache_version])
+    context_key = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:32]
+    return CacheContext(
+        space_id=space_id,
+        data_catalog=data_catalog,
+        data_schema=data_schema,
+        cache_version=cache_version,
+        cache_context_key=context_key,
+    )
+
+
+def table_name(config: dict, table: str) -> str:
+    """Return a validated three-part cache table name."""
+    _validate_uc_identifier(table, "table")
+    return f"{config['catalog']}.{config['schema']}.{table}"
+
+
+def data_schema_name(config: dict) -> str:
+    """Return the configured data catalog/schema used by cached SQL examples."""
+    context = build_cache_context(config)
+    return f"{context.data_catalog}.{context.data_schema}"
 
 
 # ---------------------------------------------------------------------------
-# Question normalization
+# Optional MLflow tracing
+# ---------------------------------------------------------------------------
+
+def mlflow_tracing_enabled(config: dict) -> bool:
+    """Return True when optional MLflow tracing should be attempted."""
+    mlflow_cfg = config.get("mlflow", {})
+    return bool(
+        mlflow_cfg.get("enable_tracing", False)
+        and os.getenv("MLFLOW_TRACKING_URI")
+        and os.getenv("MLFLOW_EXPERIMENT_ID")
+    )
+
+
+@contextlib.contextmanager
+def trace_operation(
+    config: dict,
+    name: str,
+    span_type: str = "UNKNOWN",
+    inputs: Optional[dict[str, Any]] = None,
+):
+    """Create an MLflow span when tracing is configured, otherwise no-op."""
+    if not mlflow_tracing_enabled(config):
+        yield None
+        return
+
+    try:
+        import mlflow
+        from mlflow.entities import SpanType
+
+        span_type_value = getattr(SpanType, span_type, SpanType.UNKNOWN)
+        with mlflow.start_span(name=name, span_type=span_type_value) as span:
+            if inputs:
+                span.set_inputs(_safe_trace_payload(inputs))
+            yield span
+    except Exception as e:
+        if config.get("mlflow", {}).get("debug", False):
+            print(f"  MLflow tracing disabled for span '{name}': {e}")
+        yield None
+
+
+def _safe_trace_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    safe = {}
+    for key, value in payload.items():
+        if key.lower() in {"password", "token", "secret"}:
+            safe[key] = "<redacted>"
+        elif isinstance(value, str) and len(value) > 2000:
+            safe[key] = value[:2000] + "...<truncated>"
+        else:
+            safe[key] = value
+    return safe
+
+
+# ---------------------------------------------------------------------------
+# Question normalization and cache IDs
 # ---------------------------------------------------------------------------
 
 def normalize_question(question: str) -> str:
-    """Normalize a question for exact-match dedup.
-
-    Lowercases, strips punctuation, and collapses whitespace so that trivially
-    different phrasings (trailing '?', extra spaces) map to the same key.
-    """
+    """Normalize a question for exact-match dedup."""
     q = question.lower().strip()
     q = re.sub(r"[^\w\s]", "", q)
     q = re.sub(r"\s+", " ", q)
     return q
+
+
+def deterministic_cache_id(
+    config: dict,
+    question: str,
+    cache_scope: str = GLOBAL_SCOPE,
+    session_id: Optional[str] = None,
+) -> str:
+    """Return a deterministic UUID string for a cache entry."""
+    context = build_cache_context(config)
+    session_key = _session_key(cache_scope, session_id)
+    raw = "|".join(
+        [
+            context.space_id,
+            context.cache_context_key,
+            cache_scope,
+            session_key,
+            normalize_question(question),
+        ]
+    )
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, raw))
+
+
+def _session_key(cache_scope: str, session_id: Optional[str]) -> str:
+    if cache_scope == SESSION_SCOPE:
+        if not session_id:
+            raise ValueError("session_id is required for session-scoped cache entries")
+        return session_id
+    if cache_scope != GLOBAL_SCOPE:
+        raise ValueError(f"Unsupported cache_scope: {cache_scope}")
+    return ""
+
+
+def utcnow() -> datetime:
+    """Return the current UTC time."""
+    return datetime.now(timezone.utc)
 
 
 # ---------------------------------------------------------------------------
@@ -68,32 +302,34 @@ def generate_embedding(
     instruction: Optional[str] = None,
     dimensions: Optional[int] = None,
 ) -> list[float]:
-    """Generate an embedding vector via the Databricks Foundation Model API.
-
-    Uses ``WorkspaceClient().serving_endpoints.query()`` which returns an
-    OpenAI-compatible response with ``data[0].embedding``.
-
-    Parameters
-    ----------
-    instruction : str, optional
-        Task-specific instruction for instruction-aware models (e.g.,
-        ``databricks-qwen3-embedding-0-6b``).  Can improve retrieval by 1-5%.
-    dimensions : int, optional
-        Output dimensionality for models supporting Matryoshka embeddings
-        (32-1024 for Qwen3).  Omit to use the model's native dimension.
-    """
+    """Generate an embedding vector via the Databricks Foundation Model API."""
     w = _get_workspace_client()
-    kwargs: dict = {"name": model, "input": [text]}
-    if instruction is not None:
-        kwargs["instruction"] = instruction
-    if dimensions is not None:
-        kwargs["dimensions"] = dimensions
+    extra_params: dict[str, Any] = {}
+    if instruction:
+        extra_params["instruction"] = instruction
+    if dimensions:
+        extra_params["dimensions"] = dimensions
+
+    kwargs: dict[str, Any] = {"name": model, "input": [text]}
+    if extra_params:
+        kwargs["extra_params"] = extra_params
     response = w.serving_endpoints.query(**kwargs)
     return response.data[0].embedding
 
 
+def generate_embedding_from_config(config: dict, text: str) -> list[float]:
+    """Generate an embedding using model settings from config."""
+    with trace_operation(config, "generate_embedding", "EMBEDDING", {"text": text[:200]}):
+        return generate_embedding(
+            text,
+            model=config.get("embedding_model", DEFAULT_EMBEDDING_MODEL),
+            instruction=config.get("embedding_instruction"),
+            dimensions=config.get("embedding_dimension", DEFAULT_EMBEDDING_DIMENSION),
+        )
+
+
 # ---------------------------------------------------------------------------
-# Retry with exponential backoff + decorrelated jitter
+# Retry with decorrelated jitter
 # ---------------------------------------------------------------------------
 
 def retry_with_backoff(
@@ -102,14 +338,7 @@ def retry_with_backoff(
     base_delay: float = 1.0,
     max_delay: float = 60.0,
 ):
-    """Execute *fn* with exponential backoff and decorrelated jitter.
-
-    Jitter formula: ``delay = min(max_delay, uniform(base_delay, prev_delay * 3))``
-    This avoids thundering-herd effects in distributed systems.
-
-    Only the Genie API call should be wrapped with this — cache lookups should
-    fail fast without retry.
-    """
+    """Execute *fn* with decorrelated-jitter backoff."""
     last_delay = base_delay
     for attempt in range(1, max_attempts + 1):
         try:
@@ -127,36 +356,9 @@ def retry_with_backoff(
 # ---------------------------------------------------------------------------
 # Genie API wrapper
 # ---------------------------------------------------------------------------
-# We use the Databricks Python SDK (start_conversation_and_wait) rather than:
-#   - REST API: Would require manual polling of POST /api/2.0/genie/spaces/
-#     {space_id}/start-conversation every 5-10s with no benefit over the SDK.
-#   - Databricks Managed MCP: Designed for AI agent tool use, not programmatic
-#     caching.  MCP output is not meant to be parsed programmatically, which
-#     conflicts with our need to extract SQL and response text from attachments.
-# The SDK handles long-polling automatically and provides typed response objects.
-# See: https://docs.databricks.com/aws/en/genie/conversation-api
 
-@dataclass
-class GenieResult:
-    """Parsed result from a Genie API call."""
-
-    conversation_id: str
-    message_id: str
-    generated_sql: Optional[str] = None
-    response_text: Optional[str] = None
-    latency_seconds: float = 0.0
-
-
-def call_genie(
-    space_id: str,
-    question: str,
-    timeout_minutes: int = 5,
-) -> GenieResult:
-    """Send a question to a Genie Space and return the parsed result.
-
-    Uses ``start_conversation_and_wait`` from the Databricks SDK.  On failure
-    the SDK raises, which the caller can catch or wrap with ``retry_with_backoff``.
-    """
+def call_genie(space_id: str, question: str, timeout_minutes: int = 5) -> GenieResult:
+    """Send a question to a Genie Space and return generated SQL/text."""
     w = _get_workspace_client()
     start = time.time()
 
@@ -190,19 +392,16 @@ def call_genie(
 
 
 def call_genie_with_retry(config: dict, question: str) -> GenieResult:
-    """Call the Genie API with configurable retry / backoff.
-
-    Reads ``genie_space_id``, ``genie_timeout_minutes``, and ``retry.*``
-    from *config*.
-    """
+    """Call the Genie API with configurable retry/backoff and optional tracing."""
     retry_cfg = config.get("retry", {})
 
     def _call():
-        return call_genie(
-            space_id=config["genie_space_id"],
-            question=question,
-            timeout_minutes=config.get("genie_timeout_minutes", 5),
-        )
+        with trace_operation(config, "call_genie", "LLM", {"question": question}):
+            return call_genie(
+                space_id=config["genie_space_id"],
+                question=question,
+                timeout_minutes=config.get("genie_timeout_minutes", 5),
+            )
 
     return retry_with_backoff(
         _call,
@@ -213,6 +412,54 @@ def call_genie_with_retry(config: dict, question: str) -> GenieResult:
 
 
 # ---------------------------------------------------------------------------
+# SQL execution
+# ---------------------------------------------------------------------------
+
+def execute_cached_sql(sql: str, row_limit: int = DEFAULT_RESULT_ROW_LIMIT) -> SqlExecutionResult:
+    """Execute cached SQL under the current Spark/Databricks identity."""
+    cleaned_sql = _normalize_cached_sql(sql)
+    start = time.time()
+
+    from pyspark.sql import SparkSession
+
+    spark = SparkSession.getActiveSession()
+    if spark is None:
+        raise RuntimeError("No active Spark session is available for SQL execution")
+
+    df = spark.sql(cleaned_sql)
+    preview_rows = df.limit(row_limit + 1).collect()
+    truncated = len(preview_rows) > row_limit
+    rows = [row.asDict(recursive=True) for row in preview_rows[:row_limit]]
+    return SqlExecutionResult(
+        rows=rows,
+        row_count=len(rows),
+        truncated=truncated,
+        latency_seconds=time.time() - start,
+    )
+
+
+def execute_cached_sql_with_trace(
+    config: dict,
+    sql: str,
+    row_limit: Optional[int] = None,
+) -> SqlExecutionResult:
+    """Execute cached SQL with optional MLflow tracing."""
+    limit = row_limit or int(config.get("result_row_limit", DEFAULT_RESULT_ROW_LIMIT))
+    with trace_operation(config, "execute_cached_sql", "TOOL", {"row_limit": limit, "sql": sql}):
+        return execute_cached_sql(sql, limit)
+
+
+def _normalize_cached_sql(sql: str) -> str:
+    if not sql or not sql.strip():
+        raise ValueError("Cannot execute empty cached SQL")
+    cleaned = sql.strip().rstrip(";")
+    first_token = re.sub(r"^\s*/\*.*?\*/", "", cleaned, flags=re.DOTALL).lstrip().split(None, 1)[0].lower()
+    if first_token not in {"select", "with"}:
+        raise ValueError("Cached SQL must be read-only and start with SELECT or WITH")
+    return cleaned
+
+
+# ---------------------------------------------------------------------------
 # Lakebase (PostgreSQL + pgvector) connectivity
 # ---------------------------------------------------------------------------
 
@@ -220,26 +467,17 @@ _lakebase_conn = None
 
 
 def get_lakebase_connection(config: dict):
-    """Return a cached ``psycopg`` connection to Lakebase with pgvector support.
-
-    The connection is created once and reused across calls within a notebook
-    session.  If the connection is closed or broken, a new one is created.
-
-    Credentials are fetched from Databricks Secrets using the scope and keys
-    defined in ``config["lakebase"]``.
-    """
+    """Return a cached psycopg connection to Lakebase with pgvector support."""
     global _lakebase_conn
 
     import psycopg
     from pgvector.psycopg import register_vector
 
-    # Return cached connection if still open
     if _lakebase_conn is not None:
         try:
             _lakebase_conn.execute("SELECT 1")
             return _lakebase_conn
         except Exception:
-            # Connection is broken — recreate
             try:
                 _lakebase_conn.close()
             except Exception:
@@ -248,11 +486,12 @@ def get_lakebase_connection(config: dict):
 
     lb = config["lakebase"]
 
-    # Import dbutils at call time (only available on Databricks clusters)
     from pyspark.dbutils import DBUtils
     from pyspark.sql import SparkSession
 
     spark = SparkSession.getActiveSession()
+    if spark is None:
+        raise RuntimeError("No active Spark session is available for Databricks Secrets")
     dbutils = DBUtils(spark)
 
     username = dbutils.secrets.get(scope=lb["secret_scope"], key=lb["secret_key_username"])
@@ -291,125 +530,331 @@ def lakebase_cache_lookup(
     config: dict,
     question: str,
     threshold: float,
+    cache_scope: str = GLOBAL_SCOPE,
     session_id: Optional[str] = None,
-):
-    """Check Lakebase for a cached response.
-
-    1. Exact match on normalized question text.
-    2. If no exact match, cosine similarity search via pgvector.
-
-    When *session_id* is provided, queries are scoped to that session.
-
-    Returns ``(hit_type, cached_sql, cached_response, score, embedding)``
-    where hit_type is ``"exact"``, ``"vector"``, or ``None`` on miss.
-    The embedding is returned so callers can reuse it for cache writes.
-    """
+) -> CacheLookupResult:
+    """Check Lakebase for exact or vector cache hits."""
+    context = build_cache_context(config)
+    session_key = _session_key(cache_scope, session_id)
     normalized = normalize_question(question)
-    embedding_model = config.get("embedding_model", DEFAULT_EMBEDDING_MODEL)
-    embedding_instruction = config.get("embedding_instruction")
 
-    conn = get_lakebase_connection(config)
-    with conn.cursor() as cur:
-        # --- Exact match ---
-        session_filter = "AND session_id = %s" if session_id else ""
-        params: list = [normalized]
-        if session_id:
-            params.append(session_id)
-
-        cur.execute(
-            f"SELECT cached_sql, cached_response FROM genie_cache "
-            f"WHERE question_normalized = %s {session_filter} LIMIT 1",
-            params,
-        )
-        row = cur.fetchone()
-        if row:
+    with trace_operation(
+        config,
+        "lakebase_cache_lookup",
+        "RETRIEVER",
+        {"question": question, "cache_scope": cache_scope, "session_id": session_key},
+    ):
+        conn = get_lakebase_connection(config)
+        with conn.cursor() as cur:
+            exact_params = [
+                context.space_id,
+                context.cache_context_key,
+                cache_scope,
+                session_key,
+                normalized,
+            ]
             cur.execute(
-                f"UPDATE genie_cache SET hit_count = hit_count + 1 "
-                f"WHERE question_normalized = %s {session_filter}",
-                params,
+                """
+                SELECT id, question_text, generated_sql, genie_response_text
+                FROM genie_cache
+                WHERE space_id = %s
+                  AND cache_context_key = %s
+                  AND cache_scope = %s
+                  AND session_id = %s
+                  AND question_normalized = %s
+                LIMIT 1
+                """,
+                exact_params,
             )
-            conn.commit()
-            resp = json.loads(row[1]) if row[1] else None
-            return "exact", row[0], resp, 1.0, None
+            row = cur.fetchone()
+            if row:
+                _lakebase_increment_hit(cur, row[0])
+                conn.commit()
+                return CacheLookupResult(
+                    hit_type="exact",
+                    row_id=str(row[0]),
+                    question_text=row[1],
+                    generated_sql=row[2],
+                    genie_response_text=_coerce_text(row[3]),
+                    score=1.0,
+                )
 
-        # --- Vector similarity ---
-        embedding = generate_embedding(
-            question, model=embedding_model, instruction=embedding_instruction,
-        )
-        vs_params: list = [embedding, session_id, embedding] if session_id else [embedding, embedding]
-        session_where = "WHERE session_id = %s AND embedding IS NOT NULL" if session_id else "WHERE embedding IS NOT NULL"
-
-        cur.execute(
-            f"""
-            SELECT question_normalized, cached_sql, cached_response,
-                   1 - (embedding <=> %s::vector) AS similarity
-            FROM genie_cache
-            {session_where}
-            ORDER BY embedding <=> %s::vector
-            LIMIT 1
-            """,
-            vs_params,
-        )
-        row = cur.fetchone()
-
-        if row and row[3] is not None and row[3] >= threshold:
+            embedding = generate_embedding_from_config(config, question)
+            vector_params = [
+                embedding,
+                context.space_id,
+                context.cache_context_key,
+                cache_scope,
+                session_key,
+                embedding,
+            ]
             cur.execute(
-                f"UPDATE genie_cache SET hit_count = hit_count + 1 "
-                f"WHERE question_normalized = %s {session_filter}",
-                [row[0]] + ([session_id] if session_id else []),
+                """
+                SELECT id, question_text, generated_sql, genie_response_text,
+                       1 - (embedding <=> %s::vector) AS similarity
+                FROM genie_cache
+                WHERE space_id = %s
+                  AND cache_context_key = %s
+                  AND cache_scope = %s
+                  AND session_id = %s
+                  AND embedding IS NOT NULL
+                ORDER BY embedding <=> %s::vector
+                LIMIT 1
+                """,
+                vector_params,
             )
-            conn.commit()
-            resp = json.loads(row[2]) if row[2] else None
-            return "vector", row[1], resp, float(row[3]), embedding
+            row = cur.fetchone()
+            if row and row[4] is not None and row[4] >= threshold:
+                _lakebase_increment_hit(cur, row[0])
+                conn.commit()
+                return CacheLookupResult(
+                    hit_type="vector",
+                    row_id=str(row[0]),
+                    question_text=row[1],
+                    generated_sql=row[2],
+                    genie_response_text=_coerce_text(row[3]),
+                    score=float(row[4]),
+                    embedding=embedding,
+                )
 
-    return None, None, None, 0.0, embedding
+        return CacheLookupResult(hit_type=None, score=0.0, embedding=embedding)
 
 
 def lakebase_cache_write(
     config: dict,
     question: str,
     sql: str,
-    response_text: str,
+    response_text: str = "",
+    cache_scope: str = GLOBAL_SCOPE,
     session_id: Optional[str] = None,
     embedding: Optional[list[float]] = None,
-):
-    """Write a Genie response to the Lakebase cache.
+    validated: bool = False,
+    validation_source: Optional[str] = None,
+) -> str:
+    """Upsert a generated SQL cache entry into Lakebase."""
+    if not sql or not sql.strip():
+        raise ValueError("Only Genie responses with generated SQL can be cached")
 
-    Uses ``ON CONFLICT`` to upsert.  When *session_id* is provided, the
-    ``session_id`` column is also set.
-
-    If *embedding* is provided it is reused; otherwise a new one is generated.
-    """
+    context = build_cache_context(config)
+    session_key = _session_key(cache_scope, session_id)
     normalized = normalize_question(question)
-    embedding_model = config.get("embedding_model", DEFAULT_EMBEDDING_MODEL)
-    embedding_instruction = config.get("embedding_instruction")
+    row_id = deterministic_cache_id(config, question, cache_scope, session_id)
     if embedding is None:
-        embedding = generate_embedding(
-            question, model=embedding_model, instruction=embedding_instruction,
-        )
-    response_json = json.dumps({"sql": sql, "text": response_text})
+        embedding = generate_embedding_from_config(config, question)
 
-    conn = get_lakebase_connection(config)
-    with conn.cursor() as cur:
-        cur.execute(
+    with trace_operation(
+        config,
+        "lakebase_cache_write",
+        "TOOL",
+        {"question": question, "cache_scope": cache_scope, "session_id": session_key},
+    ):
+        conn = get_lakebase_connection(config)
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO genie_cache (
+                    id, space_id, cache_context_key, cache_scope, session_id,
+                    question_text, question_normalized, embedding, generated_sql,
+                    genie_response_text, validated, validation_source
+                )
+                VALUES (
+                    %s::uuid, %s, %s, %s, %s,
+                    %s, %s, %s::vector, %s,
+                    %s, %s, %s
+                )
+                ON CONFLICT (
+                    space_id, cache_context_key, cache_scope, session_id, question_normalized
+                ) DO UPDATE SET
+                    question_text = EXCLUDED.question_text,
+                    embedding = EXCLUDED.embedding,
+                    generated_sql = EXCLUDED.generated_sql,
+                    genie_response_text = EXCLUDED.genie_response_text,
+                    validated = genie_cache.validated OR EXCLUDED.validated,
+                    validation_source = COALESCE(EXCLUDED.validation_source, genie_cache.validation_source),
+                    updated_at = now()
+                """,
+                (
+                    row_id,
+                    context.space_id,
+                    context.cache_context_key,
+                    cache_scope,
+                    session_key,
+                    question,
+                    normalized,
+                    embedding,
+                    sql,
+                    response_text or "",
+                    validated,
+                    validation_source,
+                ),
+            )
+        conn.commit()
+    return row_id
+
+
+def _lakebase_increment_hit(cur, row_id: str) -> None:
+    cur.execute(
+        """
+        UPDATE genie_cache
+        SET hit_count = hit_count + 1,
+            last_hit_at = now(),
+            updated_at = now()
+        WHERE id = %s::uuid
+        """,
+        (str(row_id),),
+    )
+
+
+def _coerce_text(value: Any) -> Optional[str]:
+    """Handle text and old JSONB values safely."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return value.get("text") or json.dumps(value)
+    return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Delta cache operations
+# ---------------------------------------------------------------------------
+
+def delta_cache_upsert(
+    spark,
+    table: str,
+    config: dict,
+    question: str,
+    sql: str,
+    response_text: str = "",
+    cache_scope: str = GLOBAL_SCOPE,
+    session_id: Optional[str] = None,
+    validated: bool = False,
+    validation_source: Optional[str] = None,
+) -> str:
+    """Upsert a deterministic cache row into a Delta table."""
+    if not sql or not sql.strip():
+        raise ValueError("Only Genie responses with generated SQL can be cached")
+
+    from pyspark.sql import Row
+
+    context = build_cache_context(config)
+    session_key = _session_key(cache_scope, session_id)
+    row_id = deterministic_cache_id(config, question, cache_scope, session_id)
+    now = utcnow()
+    view_name = f"_genie_cache_upsert_{uuid.uuid4().hex}"
+    row = Row(
+        id=row_id,
+        space_id=context.space_id,
+        cache_context_key=context.cache_context_key,
+        cache_scope=cache_scope,
+        session_id=session_key,
+        question_text=question,
+        question_normalized=normalize_question(question),
+        generated_sql=sql,
+        genie_response_text=response_text or "",
+        validated=bool(validated),
+        validation_source=validation_source,
+        created_at=now,
+        updated_at=now,
+        last_hit_at=None,
+        hit_count=0,
+    )
+    spark.createDataFrame([row]).createOrReplaceTempView(view_name)
+
+    with trace_operation(
+        config,
+        "delta_cache_upsert",
+        "TOOL",
+        {"table": table, "question": question, "cache_scope": cache_scope},
+    ):
+        spark.sql(
+            f"""
+            MERGE INTO {table} AS target
+            USING {view_name} AS source
+            ON target.id = source.id
+            WHEN MATCHED THEN UPDATE SET
+                target.question_text = source.question_text,
+                target.question_normalized = source.question_normalized,
+                target.generated_sql = source.generated_sql,
+                target.genie_response_text = source.genie_response_text,
+                target.validated = target.validated OR source.validated,
+                target.validation_source = COALESCE(source.validation_source, target.validation_source),
+                target.updated_at = source.updated_at
+            WHEN NOT MATCHED THEN INSERT (
+                id,
+                space_id,
+                cache_context_key,
+                cache_scope,
+                session_id,
+                question_text,
+                question_normalized,
+                generated_sql,
+                genie_response_text,
+                validated,
+                validation_source,
+                created_at,
+                updated_at,
+                last_hit_at,
+                hit_count
+            ) VALUES (
+                source.id,
+                source.space_id,
+                source.cache_context_key,
+                source.cache_scope,
+                source.session_id,
+                source.question_text,
+                source.question_normalized,
+                source.generated_sql,
+                source.genie_response_text,
+                source.validated,
+                source.validation_source,
+                source.created_at,
+                source.updated_at,
+                source.last_hit_at,
+                source.hit_count
+            )
             """
-            INSERT INTO genie_cache
-                (question_normalized, embedding, cached_sql, cached_response, session_id)
-            VALUES (%s, %s::vector, %s, %s::jsonb, %s)
-            ON CONFLICT (question_normalized) DO UPDATE SET
-                cached_sql = EXCLUDED.cached_sql,
-                cached_response = EXCLUDED.cached_response,
-                embedding = EXCLUDED.embedding,
-                session_id = EXCLUDED.session_id
-            """,
-            (normalized, embedding, sql, response_json, session_id),
         )
-    conn.commit()
+    return row_id
+
+
+def delta_increment_hit_count(spark, table: str, row_id: str) -> None:
+    """Increment hit metadata for a Delta cache row."""
+    spark.sql(
+        f"""
+        UPDATE {table}
+        SET hit_count = hit_count + 1,
+            last_hit_at = current_timestamp(),
+            updated_at = current_timestamp()
+        WHERE id = '{row_id}'
+        """
+    )
 
 
 # ---------------------------------------------------------------------------
 # Vector Search helpers
 # ---------------------------------------------------------------------------
+
+def vector_search_filters(
+    config: dict,
+    cache_scope: str = GLOBAL_SCOPE,
+    session_id: Optional[str] = None,
+    validated_only: bool = True,
+) -> dict[str, Any]:
+    """Return Vector Search filters for the current cache context."""
+    context = build_cache_context(config)
+    filters: dict[str, Any] = {
+        "space_id": context.space_id,
+        "cache_context_key": context.cache_context_key,
+        "cache_scope": cache_scope,
+    }
+    if cache_scope == SESSION_SCOPE:
+        filters["session_id"] = _session_key(cache_scope, session_id)
+    if validated_only:
+        filters["validated"] = True
+    return filters
+
 
 def sync_vs_index_and_wait(vsc, endpoint_name: str, index_name: str, timeout_minutes: int = 10):
     """Trigger a VS index sync and wait for completion."""
@@ -426,38 +871,34 @@ def sync_vs_index_and_wait(vsc, endpoint_name: str, index_name: str, timeout_min
             print("  VS index sync complete")
             return
         if time.time() - start > timeout_seconds:
-            print("  WARNING: Sync timed out — new entries may not be searchable yet")
+            print("  WARNING: Sync timed out; new entries may not be searchable yet")
             return
         time.sleep(5)
 
 
 # ---------------------------------------------------------------------------
-# Convenience helpers
+# Display helpers
 # ---------------------------------------------------------------------------
 
-def generate_id() -> str:
-    """Return a new UUID string for cache row IDs."""
-    return str(uuid.uuid4())
-
-
-def utcnow() -> datetime:
-    """Return the current UTC time (timezone-aware)."""
-    return datetime.now(timezone.utc)
+def print_sql_preview(result: SqlExecutionResult, max_rows: int = 5) -> None:
+    """Print a compact preview of SQL execution rows."""
+    print(
+        f"  SQL executed in {result.latency_seconds:.3f}s "
+        f"({result.row_count} preview row(s){', truncated' if result.truncated else ''})"
+    )
+    for row in result.rows[:max_rows]:
+        print(f"    {row}")
 
 
 def print_summary_table(results: list[dict], columns: list[str]):
-    """Print a formatted summary table from a list of result dicts.
-
-    *columns* is a list of keys to display.  The first column is left-aligned;
-    the rest are right-aligned with 12-char width.
-    """
+    """Print a formatted summary table from a list of result dicts."""
     header = f"{columns[0]:<50}" + "".join(f"{c:>14}" for c in columns[1:])
     print(header)
     print("-" * len(header))
     for row in results:
         line = f"{str(row[columns[0]])[:50]:<50}"
         for c in columns[1:]:
-            val = row[c]
+            val = row.get(c)
             if isinstance(val, float):
                 line += f"{val:>14.3f}"
             else:


### PR DESCRIPTION
This updates `aibi/genie-query-caching` from a WIP cache replay demo into a safer v2 reference pattern.

Main changes:
- Cache entries now store generated SQL + metadata, not authoritative natural-language answers.
- Cache hits re-execute cached SQL under the current Databricks identity, preserving freshness and access control.
- Added validated cache context keys using Genie space ID, data schema/catalog, and `cache_version`.
- Fixed Lakebase session isolation by keying on space/context/scope/session/question instead of only normalized question text.
- Fixed embedding API usage by passing instruction/dimensions through `extra_params`.
- Replaced append-only Delta writes with deterministic IDs and `MERGE` upserts.
- Added v2 schema setup with explicit incompatible-v1 detection.
- Made demo seeding optional via `seed_demo_data: false` by default.
- Added optional MLflow tracing hooks and folder-local unit tests.

Verified locally:
- `python3 -B -m py_compile aibi/genie-query-caching/*.py aibi/genie-query-caching/tests/*.py`
- `uv run pytest aibi/genie-query-caching/tests` → 8 passed
- `git diff --check -- aibi/genie-query-caching`

I did not run the Databricks smoke tests locally because this environment does not have the target Genie, Lakebase, and Vector Search resources configured.