### PR TITLE
Rebalance Genie benchmark difficulty to 5/15/10 and remove validation/conversation toggles

### DIFF
--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/banking_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/banking_genie_benchmark_loader.py
@@ -8,11 +8,10 @@
 # MAGIC benchmark portion of the space's serialized config.
 # MAGIC
 # MAGIC **What it does**
-# MAGIC 1. Validates all 30 ground-truth SQLs live on the SQL warehouse.
-# MAGIC 2. `GET`s the Genie Space (`include_serialized_space=true`).
-# MAGIC 3. Replaces `serialized_space.benchmarks.questions` with the 30 entries.
-# MAGIC 4. `PATCH`es the space back.
-# MAGIC 5. Round-trips a `GET` to verify the 30 questions landed and that
+# MAGIC 1. `GET`s the Genie Space (`include_serialized_space=true`).
+# MAGIC 2. Replaces `serialized_space.benchmarks.questions` with the 30 entries.
+# MAGIC 3. `PATCH`es the space back.
+# MAGIC 4. Round-trips a `GET` to verify the 30 questions landed and that
 # MAGIC    `data_sources` / `instructions` / `version` are unchanged.
 # MAGIC
 # MAGIC **⚠️ Safety note:** This notebook mutates **ONLY** `benchmarks.questions`.
@@ -38,16 +37,10 @@
 dbutils.widgets.text("space_id", "", "Genie Space ID (required)")
 dbutils.widgets.text("catalog", "dhuang_catalog", "Unity Catalog name")
 dbutils.widgets.text("schema", "horizon_bank", "Schema / database name")
-dbutils.widgets.text("run_sql_validation", "true", "Validate all SQLs before loading")
-dbutils.widgets.text("run_conversation_check", "false", "Sample Genie answers after load")
 
 space_id = dbutils.widgets.get("space_id").strip()
 catalog = dbutils.widgets.get("catalog").strip() or "dhuang_catalog"
 schema = dbutils.widgets.get("schema").strip() or "horizon_bank"
-run_sql_validation = dbutils.widgets.get("run_sql_validation").strip().lower() == "true"
-run_conversation_check = (
-    dbutils.widgets.get("run_conversation_check").strip().lower() == "true"
-)
 
 if not space_id:
     raise ValueError("space_id widget is required — set it to the target Genie Space ID.")
@@ -61,36 +54,26 @@ w = WorkspaceClient()  # auto-authenticates inside Databricks
 
 print(f"Target Genie Space : {space_id}")
 print(f"Data location      : {catalog}.{schema}")
-print(f"SQL validation     : {run_sql_validation}")
-print(f"Conversation check : {run_conversation_check}")
 
 # COMMAND ----------
 
 # MAGIC %md
 # MAGIC ## 2. Benchmark questions (30) — grounded in `dhuang_catalog.horizon_bank`
 # MAGIC
-# MAGIC Difficulty mix: **8 EASY / 14 MEDIUM / 8 HARD**. Every SQL references tables as
+# MAGIC Difficulty mix: **5 EASY / 15 MEDIUM / 10 HARD**. Every SQL references tables as
 # MAGIC `` `{catalog}`.`{schema}`.`<table>` `` and is rendered with
 # MAGIC `.format(catalog=catalog, schema=schema)` at use time.
 
 # COMMAND ----------
 
 BENCHMARKS = [
-    # ===================== EASY (8) =====================
+    # ===================== EASY (5) =====================
     {
         "question": "How many active customers do we currently have?",
         "difficulty": "EASY",
         "sql": """SELECT COUNT(*) AS active_customers
 FROM `{catalog}`.`{schema}`.`customers`
 WHERE is_active = TRUE""",
-    },
-    {
-        "question": "How many branches do we operate in each region?",
-        "difficulty": "EASY",
-        "sql": """SELECT region, COUNT(*) AS branch_count
-FROM `{catalog}`.`{schema}`.`branches`
-GROUP BY region
-ORDER BY branch_count DESC""",
     },
     {
         "question": "What was the total transaction amount in 2024?",
@@ -108,21 +91,6 @@ GROUP BY account_type
 ORDER BY account_count DESC""",
     },
     {
-        "question": "What is the average customer satisfaction score across resolved service requests?",
-        "difficulty": "EASY",
-        "sql": """SELECT ROUND(AVG(satisfaction_score), 2) AS avg_satisfaction_score
-FROM `{catalog}`.`{schema}`.`service_requests`
-WHERE status = 'Resolved'""",
-    },
-    {
-        "question": "How many customers fall into each relationship tier?",
-        "difficulty": "EASY",
-        "sql": """SELECT relationship_tier, COUNT(*) AS customer_count
-FROM `{catalog}`.`{schema}`.`customers`
-GROUP BY relationship_tier
-ORDER BY customer_count DESC""",
-    },
-    {
         "question": "Which products carry an annual fee of more than $50?",
         "difficulty": "EASY",
         "sql": """SELECT product_name, product_category, annual_fee_usd
@@ -137,7 +105,7 @@ ORDER BY annual_fee_usd DESC""",
 FROM `{catalog}`.`{schema}`.`transactions`
 WHERE is_flagged = TRUE""",
     },
-    # ===================== MEDIUM (14) =====================
+    # ===================== MEDIUM (15) =====================
     {
         "question": "What was the total deposit volume by region in 2024?",
         "difficulty": "MEDIUM",
@@ -281,7 +249,18 @@ JOIN `{catalog}`.`{schema}`.`customers` c ON t.customer_id = c.customer_id
 GROUP BY c.customer_segment, 2
 ORDER BY c.customer_segment, channel_type""",
     },
-    # ===================== HARD (8) =====================
+    {
+        "question": "How much fee revenue does each region generate, and how many branches contribute to it?",
+        "difficulty": "MEDIUM",
+        "sql": """SELECT b.region,
+       COUNT(DISTINCT b.branch_id) AS contributing_branches,
+       ROUND(SUM(t.fee_usd), 2) AS total_fee_revenue
+FROM `{catalog}`.`{schema}`.`transactions` t
+JOIN `{catalog}`.`{schema}`.`branches` b ON t.branch_id = b.branch_id
+GROUP BY b.region
+ORDER BY total_fee_revenue DESC""",
+    },
+    # ===================== HARD (10) =====================
     {
         "question": "For each region, which branch has the highest total transaction amount?",
         "difficulty": "HARD",
@@ -422,6 +401,41 @@ FROM per_customer
 GROUP BY relationship_tier
 ORDER BY avg_total_balance_per_customer DESC""",
     },
+    {
+        "question": "How does each branch region's service-request complaint rate compare to the bank-wide complaint rate?",
+        "difficulty": "HARD",
+        "sql": """WITH region_stats AS (
+  SELECT b.region,
+         COUNT(*) AS total_requests,
+         COUNT_IF(sr.category = 'Complaint') AS complaints
+  FROM `{catalog}`.`{schema}`.`service_requests` sr
+  JOIN `{catalog}`.`{schema}`.`branches` b ON sr.branch_id = b.branch_id
+  GROUP BY b.region
+)
+SELECT region,
+       total_requests,
+       ROUND(complaints * 100.0 / total_requests, 1) AS region_complaint_rate_pct,
+       ROUND(SUM(complaints) OVER () * 100.0 / SUM(total_requests) OVER (), 1) AS bank_complaint_rate_pct
+FROM region_stats
+ORDER BY region_complaint_rate_pct DESC""",
+    },
+    {
+        "question": "Within each product category, which products have the highest average account balance?",
+        "difficulty": "HARD",
+        "sql": """WITH product_balances AS (
+  SELECT p.product_category, p.product_name,
+         COUNT(a.account_id) AS account_count,
+         AVG(a.current_balance_usd) AS avg_balance
+  FROM `{catalog}`.`{schema}`.`accounts` a
+  JOIN `{catalog}`.`{schema}`.`products` p ON a.product_id = p.product_id
+  GROUP BY p.product_category, p.product_name
+)
+SELECT product_category, product_name, account_count,
+       ROUND(avg_balance, 2) AS avg_balance,
+       RANK() OVER (PARTITION BY product_category ORDER BY avg_balance DESC) AS rank_in_category
+FROM product_balances
+ORDER BY product_category, rank_in_category""",
+    },
 ]
 
 assert len(BENCHMARKS) == 30, f"Expected 30 benchmarks, found {len(BENCHMARKS)}"
@@ -433,46 +447,7 @@ print(f"Loaded {len(BENCHMARKS)} benchmark questions. Difficulty mix: {_diff}")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 3. Validate every SQL live (gated by `run_sql_validation`)
-# MAGIC
-# MAGIC Runs all 30 rendered SQLs against `{catalog}.{schema}`. If **any** query
-# MAGIC fails, the notebook raises and stops **before** mutating the Genie Space.
-
-# COMMAND ----------
-
-if run_sql_validation:
-    results = []
-    failures = []
-    for i, b in enumerate(BENCHMARKS, 1):
-        rendered = b["sql"].format(catalog=catalog, schema=schema)
-        try:
-            n = spark.sql(rendered).count()
-            results.append((i, b["difficulty"], "PASS", n, ""))
-        except Exception as e:  # noqa: BLE001
-            msg = str(e).splitlines()[0][:160]
-            results.append((i, b["difficulty"], "FAIL", None, msg))
-            failures.append((i, b["question"], msg))
-
-    print(f"{'#':>3}  {'DIFF':<7} {'STATUS':<6} {'ROWS':>6}  QUESTION")
-    print("-" * 100)
-    for (i, diff, status, n, _msg), b in zip(results, BENCHMARKS):
-        rows = "-" if n is None else str(n)
-        print(f"{i:>3}  {diff:<7} {status:<6} {rows:>6}  {b['question'][:62]}")
-
-    if failures:
-        for i, q, msg in failures:
-            print(f"\n  ✗ [{i}] {q}\n     {msg}")
-        raise RuntimeError(
-            f"{len(failures)} of 30 SQL validations FAILED — aborting before mutating the space."
-        )
-    print("\n✓ All 30 SQLs executed successfully — safe to load benchmarks.")
-else:
-    print("SQL validation skipped (run_sql_validation=false).")
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## 4. Fetch the Genie Space + snapshot the pre-image
+# MAGIC ## 3. Fetch the Genie Space + snapshot the pre-image
 
 # COMMAND ----------
 
@@ -483,7 +458,7 @@ resp = w.api_client.do(
 )
 serialized = json.loads(resp["serialized_space"])  # inner JSON string -> dict
 
-# Pre-image snapshots (deep copies via JSON round-trip) for step-9 verification.
+# Pre-image snapshots (deep copies via JSON round-trip) for step-6 verification.
 pre_data_sources = json.loads(json.dumps(serialized.get("data_sources")))
 pre_instructions = json.loads(json.dumps(serialized.get("instructions")))
 pre_version = serialized.get("version")
@@ -501,7 +476,7 @@ print(f"  data_sources tables   : {len((serialized.get('data_sources') or {}).ge
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 5. Build benchmark entries and mutate ONLY `benchmarks.questions`
+# MAGIC ## 4. Build benchmark entries and mutate ONLY `benchmarks.questions`
 
 # COMMAND ----------
 
@@ -531,7 +506,7 @@ print("Mutated keys: benchmarks.questions (+ version setdefault). Nothing else c
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 6. PATCH the space (echo existing metadata so nothing else is clobbered)
+# MAGIC ## 5. PATCH the space (echo existing metadata so nothing else is clobbered)
 
 # COMMAND ----------
 
@@ -546,7 +521,7 @@ print("PATCH submitted — benchmark questions written to the space.")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 7. Round-trip verification
+# MAGIC ## 6. Round-trip verification
 
 # COMMAND ----------
 
@@ -582,58 +557,3 @@ print(f"  data_sources unchanged      : True")
 print(f"  instructions unchanged      : True")
 print(f"  version unchanged           : True (={serialized2.get('version')})")
 print(f"  Space                       : {resp2.get('title')} ({space_id})")
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## 8. (Optional) Conversation spot-check (gated by `run_conversation_check`)
-# MAGIC
-# MAGIC For a small SAMPLE of questions, exercise the Genie Conversation API and print
-# MAGIC Genie's answer for manual review. Off by default; best-effort (never blocks).
-
-# COMMAND ----------
-
-if run_conversation_check:
-    import time
-
-    SAMPLE_N = 3
-    sample = BENCHMARKS[:SAMPLE_N]
-    for b in sample:
-        q = b["question"]
-        print("=" * 70)
-        print(f"Q ({b['difficulty']}): {q}")
-        try:
-            start = w.api_client.do(
-                "POST",
-                f"/api/2.0/genie/spaces/{space_id}/start-conversation",
-                body={"content": q},
-            )
-            conv_id = start.get("conversation_id") or start.get("conversation", {}).get("id")
-            msg_id = start.get("message_id") or start.get("message", {}).get("id")
-            if not (conv_id and msg_id):
-                print(f"  (could not parse conversation/message id: {start})")
-                continue
-
-            status, msg = None, {}
-            for _ in range(30):  # up to ~2.5 min
-                msg = w.api_client.do(
-                    "GET",
-                    f"/api/2.0/genie/spaces/{space_id}/conversations/{conv_id}/messages/{msg_id}",
-                )
-                status = msg.get("status")
-                if status in ("COMPLETED", "FAILED", "CANCELLED", "QUERY_RESULT_EXPIRED"):
-                    break
-                time.sleep(5)
-
-            print(f"  status: {status}")
-            for att in msg.get("attachments", []) or []:
-                if "text" in att and att["text"]:
-                    print(f"  text  : {att['text'].get('content', '')[:300]}")
-                if "query" in att and att["query"]:
-                    print(f"  query : {att['query'].get('query', '')[:400]}")
-        except Exception as e:  # noqa: BLE001
-            print(f"  (conversation check error: {str(e).splitlines()[0][:160]})")
-    print("=" * 70)
-    print("Conversation spot-check complete (manual review).")
-else:
-    print("Conversation check skipped (run_conversation_check=false).")

--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/hospital_readmission_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/hospital_readmission_genie_benchmark_loader.py
@@ -8,11 +8,10 @@
 # MAGIC portion of the space's serialized config.
 # MAGIC
 # MAGIC **What it does**
-# MAGIC 1. Validates all 30 ground-truth SQLs live against `dhuang_catalog.hospital_readmission`.
-# MAGIC 2. `GET`s the Genie Space (with `include_serialized_space=true`).
-# MAGIC 3. Replaces `serialized["benchmarks"]["questions"]` with the 30 entries.
-# MAGIC 4. `PATCH`es the space (echoing existing title/description/warehouse_id).
-# MAGIC 5. Round-trip verifies the 30 questions landed and nothing else changed.
+# MAGIC 1. `GET`s the Genie Space (with `include_serialized_space=true`).
+# MAGIC 2. Replaces `serialized["benchmarks"]["questions"]` with the 30 entries.
+# MAGIC 3. `PATCH`es the space (echoing existing title/description/warehouse_id).
+# MAGIC 4. Round-trip verifies the 30 questions landed and nothing else changed.
 # MAGIC
 # MAGIC **SAFETY:** This notebook mutates **ONLY** `benchmarks.questions`. It does NOT
 # MAGIC touch `config`, `data_sources`, `instructions`, or `version` of the space.
@@ -38,23 +37,17 @@
 dbutils.widgets.text("space_id", "", "Target Genie Space ID (required)")
 dbutils.widgets.text("catalog", "dhuang_catalog", "Unity Catalog name")
 dbutils.widgets.text("schema", "hospital_readmission", "Schema / database name")
-dbutils.widgets.dropdown("run_sql_validation", "true", ["true", "false"], "Validate SQL live before load")
-dbutils.widgets.dropdown("run_conversation_check", "false", ["true", "false"], "Sampled Genie conversation check")
 
 space_id = dbutils.widgets.get("space_id").strip()
 catalog = dbutils.widgets.get("catalog").strip()
 schema = dbutils.widgets.get("schema").strip()
-run_sql_validation = dbutils.widgets.get("run_sql_validation").strip().lower() == "true"
-run_conversation_check = dbutils.widgets.get("run_conversation_check").strip().lower() == "true"
 
 if not space_id:
     raise ValueError("Widget 'space_id' is required (the target Genie Space ID).")
 
-print(f"space_id               : {space_id}")
-print(f"catalog                : {catalog}")
-print(f"schema                 : {schema}")
-print(f"run_sql_validation     : {run_sql_validation}")
-print(f"run_conversation_check : {run_conversation_check}")
+print(f"space_id : {space_id}")
+print(f"catalog  : {catalog}")
+print(f"schema   : {schema}")
 
 # COMMAND ----------
 
@@ -76,7 +69,7 @@ print("WorkspaceClient ready.")
 # MAGIC and the ground-truth Databricks SQL. Tables are referenced with `{catalog}` /
 # MAGIC `{schema}` Python format placeholders, rendered from the widgets at load time.
 # MAGIC
-# MAGIC Mix: 8 EASY / 14 MEDIUM / 8 HARD. Note: each encounter has at most one
+# MAGIC Mix: 5 EASY / 15 MEDIUM / 10 HARD. Note: each encounter has at most one
 # MAGIC readmission row, so `COUNT(DISTINCT readmission_id) / COUNT(DISTINCT encounter_id)`
 # MAGIC is the 30-day readmission rate.
 
@@ -119,32 +112,6 @@ ORDER BY encounter_count DESC""",
 FROM `{catalog}`.`{schema}`.`patients`
 GROUP BY clinical_risk_band
 ORDER BY patient_count DESC""",
-    },
-    {
-        "question": "How many claims are in each claim status, and what is the total allowed amount for each?",
-        "difficulty": "EASY",
-        "sql": """SELECT claim_status,
-       COUNT(*) AS claim_count,
-       ROUND(SUM(allowed_amount_usd), 2) AS total_allowed_amount_usd
-FROM `{catalog}`.`{schema}`.`claims`
-GROUP BY claim_status
-ORDER BY claim_count DESC""",
-    },
-    {
-        "question": "How many encounters were discharged over a weekend, and what percentage of all discharges is that?",
-        "difficulty": "EASY",
-        "sql": """SELECT COUNT(*) AS total_encounters,
-       SUM(CASE WHEN weekend_discharge THEN 1 ELSE 0 END) AS weekend_discharges,
-       ROUND(SUM(CASE WHEN weekend_discharge THEN 1 ELSE 0 END) * 100.0 / COUNT(*), 1) AS weekend_discharge_pct
-FROM `{catalog}`.`{schema}`.`encounters`""",
-    },
-    {
-        "question": "Of all 30-day readmissions, how many were planned and what share were unplanned?",
-        "difficulty": "EASY",
-        "sql": """SELECT COUNT(*) AS total_readmissions,
-       SUM(CASE WHEN planned_readmission THEN 1 ELSE 0 END) AS planned_readmissions,
-       ROUND(SUM(CASE WHEN NOT planned_readmission THEN 1 ELSE 0 END) * 100.0 / COUNT(*), 1) AS unplanned_pct
-FROM `{catalog}`.`{schema}`.`readmissions`""",
     },
     {
         "question": "What is our overall 30-day readmission rate?",
@@ -320,6 +287,19 @@ GROUP BY e.discharge_disposition
 ORDER BY readmission_rate_pct DESC""",
     },
     {
+        "question": "What is the total allowed claim amount and the denial rate for each hospital region?",
+        "difficulty": "MEDIUM",
+        "sql": """SELECT h.region,
+       COUNT(*) AS claim_count,
+       ROUND(SUM(c.allowed_amount_usd), 2) AS total_allowed_usd,
+       ROUND(SUM(CASE WHEN c.claim_status = 'Denied' THEN 1 ELSE 0 END) * 100.0 / COUNT(*), 2) AS denial_rate_pct
+FROM `{catalog}`.`{schema}`.`claims` c
+JOIN `{catalog}`.`{schema}`.`hospitals` h
+  ON c.hospital_id = h.hospital_id
+GROUP BY h.region
+ORDER BY total_allowed_usd DESC""",
+    },
+    {
         "question": "For each diagnosis group, which hospital has the highest 30-day readmission rate among hospitals with at least 50 encounters for that diagnosis?",
         "difficulty": "HARD",
         "sql": """WITH diag_hosp AS (
@@ -484,6 +464,52 @@ WHERE p.clinical_risk_band IN ('High', 'Very High')
 GROUP BY 1
 ORDER BY readmission_rate_pct DESC""",
     },
+    {
+        "question": "By hospital region, how does the 30-day readmission rate compare for weekend versus weekday discharges, and what is the gap in percentage points?",
+        "difficulty": "HARD",
+        "sql": """WITH region_rates AS (
+  SELECT h.region,
+         COUNT(DISTINCT CASE WHEN e.weekend_discharge THEN e.encounter_id END) AS weekend_encounters,
+         COUNT(DISTINCT CASE WHEN e.weekend_discharge THEN r.readmission_id END) AS weekend_readmissions,
+         COUNT(DISTINCT CASE WHEN NOT e.weekend_discharge THEN e.encounter_id END) AS weekday_encounters,
+         COUNT(DISTINCT CASE WHEN NOT e.weekend_discharge THEN r.readmission_id END) AS weekday_readmissions
+  FROM `{catalog}`.`{schema}`.`encounters` e
+  JOIN `{catalog}`.`{schema}`.`hospitals` h
+    ON e.hospital_id = h.hospital_id
+  LEFT JOIN `{catalog}`.`{schema}`.`readmissions` r
+    ON e.encounter_id = r.index_encounter_id
+  GROUP BY h.region
+)
+SELECT region,
+       ROUND(weekend_readmissions * 100.0 / NULLIF(weekend_encounters, 0), 2) AS weekend_readmission_rate_pct,
+       ROUND(weekday_readmissions * 100.0 / NULLIF(weekday_encounters, 0), 2) AS weekday_readmission_rate_pct,
+       ROUND(weekend_readmissions * 100.0 / NULLIF(weekend_encounters, 0)
+           - weekday_readmissions * 100.0 / NULLIF(weekday_encounters, 0), 2) AS weekend_minus_weekday_pp
+FROM region_rates
+ORDER BY weekend_minus_weekday_pp DESC""",
+    },
+    {
+        "question": "Which index-admission diagnosis groups drive the most unplanned 30-day readmissions, and what cumulative share of all unplanned readmissions do they account for?",
+        "difficulty": "HARD",
+        "sql": """WITH unplanned AS (
+  SELECT e.primary_diagnosis_group AS diagnosis_group,
+         COUNT(*) AS unplanned_readmissions
+  FROM `{catalog}`.`{schema}`.`readmissions` r
+  JOIN `{catalog}`.`{schema}`.`encounters` e
+    ON r.index_encounter_id = e.encounter_id
+  WHERE NOT r.planned_readmission
+  GROUP BY e.primary_diagnosis_group
+)
+SELECT diagnosis_group,
+       unplanned_readmissions,
+       ROUND(unplanned_readmissions * 100.0 / SUM(unplanned_readmissions) OVER (), 2) AS pct_of_unplanned,
+       ROUND(SUM(unplanned_readmissions) OVER (
+               ORDER BY unplanned_readmissions DESC
+               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+             ) * 100.0 / SUM(unplanned_readmissions) OVER (), 2) AS cumulative_pct_of_unplanned
+FROM unplanned
+ORDER BY unplanned_readmissions DESC""",
+    },
 ]
 
 assert len(BENCHMARKS) == 30, f"Expected 30 benchmarks, found {len(BENCHMARKS)}"
@@ -495,45 +521,7 @@ print(f"Loaded {len(BENCHMARKS)} benchmarks. Difficulty mix: {_mix}")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 3. Validate all 30 SQLs live (gated by `run_sql_validation`)
-# MAGIC
-# MAGIC Runs every ground-truth SQL against the live data. If ANY query fails, the
-# MAGIC notebook raises and stops BEFORE touching the Genie Space.
-
-# COMMAND ----------
-
-if run_sql_validation:
-    results = []
-    failures = []
-    for i, b in enumerate(BENCHMARKS, start=1):
-        rendered = b["sql"].format(catalog=catalog, schema=schema)
-        try:
-            n = spark.sql(rendered).count()
-            results.append((i, b["difficulty"], "PASS", n, ""))
-        except Exception as exc:  # noqa: BLE001
-            msg = str(exc).splitlines()[0][:160]
-            results.append((i, b["difficulty"], "FAIL", 0, msg))
-            failures.append((i, b["question"], msg))
-
-    print(f"{'#':>3}  {'DIFF':<6} {'STATUS':<6} {'ROWS':>6}  NOTE")
-    print("-" * 90)
-    for i, diff, status, n, note in results:
-        print(f"{i:>3}  {diff:<6} {status:<6} {n:>6}  {note}")
-    print("-" * 90)
-
-    if failures:
-        raise RuntimeError(
-            f"{len(failures)} SQL(s) failed validation; aborting before mutating the Genie Space:\n"
-            + "\n".join(f"  [{i}] {q} -> {m}" for i, q, m in failures)
-        )
-    print(f"\nAll {len(BENCHMARKS)} SQLs validated successfully against `{catalog}`.`{schema}`.")
-else:
-    print("run_sql_validation=false -> skipping live SQL validation.")
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## 4. Fetch the Genie Space (pre-image snapshot)
+# MAGIC ## 3. Fetch the Genie Space (pre-image snapshot)
 
 # COMMAND ----------
 
@@ -544,7 +532,7 @@ resp = w.api_client.do(
 )
 serialized = json.loads(resp["serialized_space"])  # inner JSON string -> dict
 
-# Pre-image snapshots used for the round-trip verification (step 6).
+# Pre-image snapshots used for the round-trip verification (step 5).
 import copy
 
 pre_data_sources = copy.deepcopy(serialized.get("data_sources"))
@@ -563,7 +551,7 @@ if isinstance(ds_tables, list):
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 5. Mutate ONLY `benchmarks.questions`, then PATCH
+# MAGIC ## 4. Mutate ONLY `benchmarks.questions`, then PATCH
 
 # COMMAND ----------
 
@@ -600,7 +588,7 @@ print(f"PATCH submitted: replaced benchmarks.questions with {len(questions)} ent
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 6. Round-trip verification
+# MAGIC ## 5. Round-trip verification
 
 # COMMAND ----------
 
@@ -643,58 +631,3 @@ print(f"  data_sources unchanged      : True")
 print(f"  instructions unchanged      : True")
 print(f"  version unchanged           : True ({serialized2.get('version')})")
 print(f"  space                       : {resp2.get('title')!r} ({space_id})")
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## 7. (Optional) Sampled Genie conversation check
-# MAGIC
-# MAGIC Gated by `run_conversation_check` (default off). For a small SAMPLE of questions,
-# MAGIC exercises the Conversation API end-to-end and prints Genie's answer for manual
-# MAGIC spot-checking. This actually runs Genie and may take a while.
-
-# COMMAND ----------
-
-if run_conversation_check:
-    import time
-
-    SAMPLE_N = 3
-    sample = BENCHMARKS[:SAMPLE_N]
-
-    def _poll_message(space_id, conversation_id, message_id, timeout_s=180, interval_s=4):
-        deadline = time.time() + timeout_s
-        while time.time() < deadline:
-            msg = w.api_client.do(
-                "GET",
-                f"/api/2.0/genie/spaces/{space_id}/conversations/{conversation_id}/messages/{message_id}",
-            )
-            status = msg.get("status")
-            if status in ("COMPLETED", "FAILED", "CANCELLED", "QUERY_RESULT_EXPIRED"):
-                return msg
-            time.sleep(interval_s)
-        return {"status": "TIMEOUT"}
-
-    for i, b in enumerate(sample, start=1):
-        print("=" * 80)
-        print(f"[{i}/{len(sample)}] ({b['difficulty']}) {b['question']}")
-        start = w.api_client.do(
-            "POST",
-            f"/api/2.0/genie/spaces/{space_id}/start-conversation",
-            body={"content": b["question"]},
-        )
-        conversation_id = start.get("conversation_id") or start.get("conversation", {}).get("id")
-        message_id = start.get("message_id") or start.get("message", {}).get("id")
-        if not conversation_id or not message_id:
-            print(f"  Could not start conversation; raw response keys: {sorted(start.keys())}")
-            continue
-        msg = _poll_message(space_id, conversation_id, message_id)
-        print(f"  status: {msg.get('status')}")
-        for att in msg.get("attachments", []) or []:
-            if "text" in att and att["text"]:
-                print(f"  text: {att['text'].get('content')}")
-            if "query" in att and att["query"]:
-                print(f"  query: {att['query'].get('query')}")
-    print("=" * 80)
-    print("Conversation check complete (manual spot-check above).")
-else:
-    print("run_conversation_check=false -> skipping sampled Genie conversation check.")

--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/retail_apparel_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/retail_apparel_genie_benchmark_loader.py
@@ -3,9 +3,12 @@
 # MAGIC %md
 # MAGIC # Retail Apparel Genie Benchmark Loader
 # MAGIC
-# MAGIC Loads 30 benchmark questions for the retail apparel Genie Space.
+# MAGIC Loads 30 benchmark questions (5 EASY / 15 MEDIUM / 10 HARD) into the retail apparel Genie Space and round-trip verifies the result.
 # MAGIC
-# MAGIC Safety note: this notebook mutates ONLY `benchmarks.questions` in the serialized Genie Space config. It fetches the current space, replaces the benchmark question list, patches the space, and verifies that `data_sources`, `instructions`, and `version` are unchanged.
+# MAGIC What this notebook does:
+# MAGIC - Builds the 30-question `BENCHMARKS` list (SQL answers grounded in `{catalog}`.`{schema}`).
+# MAGIC - Fetches the target Genie Space and mutates ONLY `benchmarks.questions` in its serialized config.
+# MAGIC - Patches the space, then round-trip verifies that `data_sources`, `instructions`, and `version` are unchanged.
 
 # COMMAND ----------
 
@@ -21,7 +24,6 @@
 
 import copy
 import json
-import time
 import uuid
 
 from databricks.sdk import WorkspaceClient
@@ -29,14 +31,10 @@ from databricks.sdk import WorkspaceClient
 dbutils.widgets.text("space_id", "", "Target Genie Space ID")
 dbutils.widgets.text("catalog", "dhuang_catalog", "Unity Catalog")
 dbutils.widgets.text("schema", "retail_apparel", "Schema")
-dbutils.widgets.dropdown("run_sql_validation", "true", ["true", "false"], "Run SQL validation")
-dbutils.widgets.dropdown("run_conversation_check", "false", ["true", "false"], "Run conversation spot check")
 
 space_id = dbutils.widgets.get("space_id").strip()
 catalog = dbutils.widgets.get("catalog").strip() or "dhuang_catalog"
 schema = dbutils.widgets.get("schema").strip() or "retail_apparel"
-run_sql_validation = dbutils.widgets.get("run_sql_validation").strip().lower() == "true"
-run_conversation_check = dbutils.widgets.get("run_conversation_check").strip().lower() == "true"
 
 if not space_id:
     raise ValueError("Widget 'space_id' is required.")
@@ -51,6 +49,7 @@ w = WorkspaceClient()
 # COMMAND ----------
 
 BENCHMARKS = [
+    # ------------------------------------------------------------------ EASY (5)
     {
         "question": "Which product categories have the most active products, and what is their average list price?",
         "difficulty": "EASY",
@@ -93,20 +92,6 @@ ORDER BY `active_customer_count` DESC, `loyalty_tier`
 """.strip(),
     },
     {
-        "question": "What were monthly units sold and net sales in 2025?",
-        "difficulty": "EASY",
-        "sql": """
-SELECT
-  CAST(`Sale Month` AS DATE) AS `sale_month`,
-  MEASURE(`Units Sold`) AS `units_sold`,
-  ROUND(MEASURE(`Net Sales`), 2) AS `net_sales_usd`
-FROM `{catalog}`.`{schema}`.`mv_retail_sales`
-WHERE `Sale Year` = 2025
-GROUP BY `Sale Month`
-ORDER BY `sale_month`
-""".strip(),
-    },
-    {
         "question": "Which sales channel generated the most net sales overall?",
         "difficulty": "EASY",
         "sql": """
@@ -118,34 +103,6 @@ SELECT
 FROM `{catalog}`.`{schema}`.`sales`
 GROUP BY `channel`
 ORDER BY `net_sales_usd` DESC, `channel`
-""".strip(),
-    },
-    {
-        "question": "What are total returns and return dollars by return reason?",
-        "difficulty": "EASY",
-        "sql": """
-SELECT
-  `Return Reason` AS `return_reason`,
-  MEASURE(`Return Count`) AS `return_count`,
-  MEASURE(`Returned Units`) AS `returned_units`,
-  ROUND(MEASURE(`Return Amount`), 2) AS `return_amount_usd`
-FROM `{catalog}`.`{schema}`.`mv_retail_returns`
-GROUP BY `Return Reason`
-ORDER BY `return_count` DESC, `return_reason`
-""".strip(),
-    },
-    {
-        "question": "Which product seasons have the highest average list price and target margin?",
-        "difficulty": "EASY",
-        "sql": """
-SELECT
-  `season`,
-  COUNT(*) AS `product_count`,
-  ROUND(AVG(`list_price_usd`), 2) AS `avg_list_price_usd`,
-  ROUND(AVG(`target_margin_pct`), 2) AS `avg_target_margin_pct`
-FROM `{catalog}`.`{schema}`.`products`
-GROUP BY `season`
-ORDER BY `avg_list_price_usd` DESC, `season`
 """.strip(),
     },
     {
@@ -162,6 +119,7 @@ ORDER BY `stockout_days` DESC, `snapshot_month`
 LIMIT 10
 """.strip(),
     },
+    # ---------------------------------------------------------------- MEDIUM (15)
     {
         "question": "Which product categories generated the most net sales and gross margin?",
         "difficulty": "MEDIUM",
@@ -465,6 +423,27 @@ HAVING SUM(s.`net_sales_usd`) > 0
 ORDER BY `gross_margin_pct` DESC, p.`brand_line`
 """.strip(),
     },
+    {
+        "question": "For each product season, what were 2025 units sold, net sales, and realized gross margin percent?",
+        "difficulty": "MEDIUM",
+        "sql": """
+SELECT
+  p.`season`,
+  COUNT(*) AS `order_count`,
+  SUM(s.`quantity`) AS `units_sold`,
+  ROUND(SUM(s.`net_sales_usd`), 2) AS `net_sales_usd`,
+  ROUND(SUM(s.`gross_margin_usd`), 2) AS `gross_margin_usd`,
+  ROUND(SUM(s.`gross_margin_usd`) * 100.0 / SUM(s.`net_sales_usd`), 2) AS `gross_margin_pct`
+FROM `{catalog}`.`{schema}`.`sales` s
+JOIN `{catalog}`.`{schema}`.`products` p
+  ON s.`product_id` = p.`product_id`
+WHERE s.`sale_year` = 2025
+GROUP BY p.`season`
+HAVING SUM(s.`net_sales_usd`) > 0
+ORDER BY `gross_margin_pct` DESC, p.`season`
+""".strip(),
+    },
+    # ------------------------------------------------------------------ HARD (10)
     {
         "question": "Which product categories had the strongest net sales growth from 2024 to 2025?",
         "difficulty": "HARD",
@@ -789,59 +768,90 @@ LEFT JOIN inventory_burden ib
 ORDER BY `gross_margin_per_annual_rent_dollar` DESC, ss.`store_id`
 """.strip(),
     },
+    {
+        "question": "For each product category, how did monthly net sales change month over month in 2025?",
+        "difficulty": "HARD",
+        "sql": """
+WITH category_month_sales AS (
+  SELECT
+    p.`category`,
+    s.`sale_month`,
+    SUM(s.`quantity`) AS `units_sold`,
+    SUM(s.`net_sales_usd`) AS `net_sales_usd`
+  FROM `{catalog}`.`{schema}`.`sales` s
+  JOIN `{catalog}`.`{schema}`.`products` p
+    ON s.`product_id` = p.`product_id`
+  WHERE s.`sale_year` = 2025
+  GROUP BY p.`category`, s.`sale_month`
+)
+SELECT
+  `category`,
+  `sale_month`,
+  `units_sold`,
+  ROUND(`net_sales_usd`, 2) AS `net_sales_usd`,
+  ROUND(LAG(`net_sales_usd`) OVER (PARTITION BY `category` ORDER BY `sale_month`), 2) AS `prev_month_net_sales_usd`,
+  ROUND(
+    (`net_sales_usd` - LAG(`net_sales_usd`) OVER (PARTITION BY `category` ORDER BY `sale_month`))
+      * 100.0 / NULLIF(LAG(`net_sales_usd`) OVER (PARTITION BY `category` ORDER BY `sale_month`), 0),
+    2
+  ) AS `mom_growth_pct`
+FROM category_month_sales
+ORDER BY `category`, `sale_month`
+""".strip(),
+    },
+    {
+        "question": "What was 2025 inventory turnover (cost of goods sold divided by average inventory value) by product category?",
+        "difficulty": "HARD",
+        "sql": """
+WITH category_cogs AS (
+  SELECT
+    p.`category`,
+    ROUND(SUM(s.`quantity` * s.`unit_cost_usd`), 2) AS `cogs_2025_usd`
+  FROM `{catalog}`.`{schema}`.`sales` s
+  JOIN `{catalog}`.`{schema}`.`products` p
+    ON s.`product_id` = p.`product_id`
+  WHERE s.`sale_year` = 2025
+  GROUP BY p.`category`
+),
+monthly_category_inventory AS (
+  SELECT
+    p.`category`,
+    i.`snapshot_month`,
+    SUM(i.`inventory_value_usd`) AS `month_inventory_value_usd`
+  FROM `{catalog}`.`{schema}`.`inventory_snapshots` i
+  JOIN `{catalog}`.`{schema}`.`products` p
+    ON i.`product_id` = p.`product_id`
+  WHERE i.`snapshot_year` = 2025
+  GROUP BY p.`category`, i.`snapshot_month`
+),
+avg_category_inventory AS (
+  -- Inventory value is a point-in-time LEVEL per snapshot month, so the turnover
+  -- denominator is the AVERAGE of the monthly inventory levels -- never the sum of
+  -- month-end values across months, which would inflate the base ~12x.
+  SELECT
+    `category`,
+    ROUND(AVG(`month_inventory_value_usd`), 2) AS `avg_inventory_value_usd`
+  FROM monthly_category_inventory
+  GROUP BY `category`
+)
+SELECT
+  c.`category`,
+  c.`cogs_2025_usd`,
+  a.`avg_inventory_value_usd`,
+  ROUND(c.`cogs_2025_usd` / a.`avg_inventory_value_usd`, 2) AS `inventory_turnover`
+FROM category_cogs c
+JOIN avg_category_inventory a
+  ON c.`category` = a.`category`
+ORDER BY `inventory_turnover` DESC, c.`category`
+""".strip(),
+    },
 ]
 
 assert len(BENCHMARKS) == 30, f"Expected 30 benchmarks, found {len(BENCHMARKS)}"
 assert {b["difficulty"] for b in BENCHMARKS} <= {"EASY", "MEDIUM", "HARD"}
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## Validate SQL
-
-# COMMAND ----------
-
-if run_sql_validation:
-    validation_results = []
-    failures = []
-
-    for idx, benchmark in enumerate(BENCHMARKS, start=1):
-        rendered_sql = benchmark["sql"].format(catalog=catalog, schema=schema)
-        try:
-            rows = spark.sql(rendered_sql).collect()
-            validation_results.append(
-                {
-                    "question_number": idx,
-                    "difficulty": benchmark["difficulty"],
-                    "status": "PASS",
-                    "row_count": len(rows),
-                    "question": benchmark["question"],
-                }
-            )
-        except Exception as exc:
-            failures.append((idx, benchmark["question"], rendered_sql, str(exc)))
-            validation_results.append(
-                {
-                    "question_number": idx,
-                    "difficulty": benchmark["difficulty"],
-                    "status": "FAIL",
-                    "row_count": None,
-                    "question": benchmark["question"],
-                }
-            )
-
-    spark.createDataFrame(validation_results).orderBy("question_number").show(30, truncate=False)
-
-    if failures:
-        failure_text = "\n\n".join(
-            f"Question {idx}: {question}\nError: {error}\nSQL:\n{sql}"
-            for idx, question, sql, error in failures
-        )
-        raise RuntimeError(f"SQL validation failed for {len(failures)} benchmark(s):\n{failure_text}")
-
-    print(f"Validated {len(validation_results)} benchmark SQL statements against `{catalog}`.`{schema}`.")
-else:
-    print("Skipping SQL validation because run_sql_validation=false.")
+assert sum(b["difficulty"] == "EASY" for b in BENCHMARKS) == 5, "Expected 5 EASY benchmarks"
+assert sum(b["difficulty"] == "MEDIUM" for b in BENCHMARKS) == 15, "Expected 15 MEDIUM benchmarks"
+assert sum(b["difficulty"] == "HARD" for b in BENCHMARKS) == 10, "Expected 10 HARD benchmarks"
 
 # COMMAND ----------
 
@@ -927,54 +937,3 @@ print(f"  Genie Space ID: {space_id}")
 print(f"  Catalog/schema: `{catalog}`.`{schema}`")
 print(f"  Benchmark questions: {len(actual_questions)}")
 print("  Verified unchanged: data_sources, instructions, version")
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## Optional Conversation Spot Check
-
-# COMMAND ----------
-
-def _message_text(message):
-    for key in ("content", "text", "answer"):
-        value = message.get(key)
-        if isinstance(value, str):
-            return value
-        if isinstance(value, list):
-            return " ".join(str(item) for item in value)
-    attachments = message.get("attachments") or []
-    return json.dumps(attachments)[:2000]
-
-
-if run_conversation_check:
-    sample = BENCHMARKS[:3]
-    for benchmark in sample:
-        start = w.api_client.do(
-            "POST",
-            f"/api/2.0/genie/spaces/{space_id}/start-conversation",
-            body={"content": benchmark["question"]},
-        )
-        conversation_id = start.get("conversation_id") or start.get("conversation", {}).get("id")
-        message_id = start.get("message_id") or start.get("message", {}).get("id")
-
-        if not conversation_id or not message_id:
-            print(f"Started conversation for: {benchmark['question']}")
-            print(json.dumps(start, indent=2)[:2000])
-            continue
-
-        message = {}
-        for _ in range(30):
-            message = w.api_client.do(
-                "GET",
-                f"/api/2.0/genie/spaces/{space_id}/conversations/{conversation_id}/messages/{message_id}",
-            )
-            status = str(message.get("status", "")).upper()
-            if status in {"COMPLETED", "FAILED", "CANCELLED"}:
-                break
-            time.sleep(2)
-
-        print("=" * 80)
-        print(benchmark["question"])
-        print(_message_text(message))
-else:
-    print("Skipping conversation spot check because run_conversation_check=false.")

--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/saas_churn_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/saas_churn_genie_benchmark_loader.py
@@ -35,8 +35,6 @@ def create_text_widget(name, default, label):
 create_text_widget("space_id", "", "Target Genie Space ID")
 create_text_widget("catalog", DEFAULT_CATALOG, "Unity Catalog name")
 create_text_widget("schema", DEFAULT_SCHEMA, "Schema name")
-create_text_widget("run_sql_validation", "true", "Run SQL validation before patch")
-create_text_widget("run_conversation_check", "false", "Run optional Genie conversation spot-check")
 
 
 def widget_value(name, default=""):
@@ -50,8 +48,6 @@ def widget_value(name, default=""):
 space_id = widget_value("space_id")
 catalog = widget_value("catalog", DEFAULT_CATALOG)
 schema = widget_value("schema", DEFAULT_SCHEMA)
-run_sql_validation = widget_value("run_sql_validation", "true").lower() == "true"
-run_conversation_check = widget_value("run_conversation_check", "false").lower() == "true"
 
 if not space_id:
     raise ValueError("The space_id widget is required.")
@@ -68,19 +64,6 @@ print(f"Configured benchmark loader for `{catalog}`.`{schema}`")
 # COMMAND ----------
 
 BENCHMARKS = [
-    {
-        "question": "How many accounts do we have by customer segment and active status?",
-        "difficulty": "EASY",
-        "sql": """
-SELECT
-  `segment`,
-  `is_active`,
-  COUNT(*) AS `account_count`
-FROM `{catalog}`.`{schema}`.`accounts`
-GROUP BY `segment`, `is_active`
-ORDER BY `segment`, `is_active` DESC
-""",
-    },
     {
         "question": "What are total ARR and MRR by subscription status?",
         "difficulty": "EASY",
@@ -144,20 +127,6 @@ ORDER BY
 """,
     },
     {
-        "question": "What invoice dollars are paid, late, or still open?",
-        "difficulty": "EASY",
-        "sql": """
-SELECT
-  `payment_status`,
-  COUNT(*) AS `invoice_count`,
-  ROUND(SUM(`amount_due_usd`), 2) AS `total_due_usd`,
-  ROUND(SUM(`amount_paid_usd`), 2) AS `total_paid_usd`
-FROM `{catalog}`.`{schema}`.`invoices`
-GROUP BY `payment_status`
-ORDER BY `total_due_usd` DESC, `payment_status`
-""",
-    },
-    {
         "question": "What was average seat utilization and health score by plan tier in 2025?",
         "difficulty": "EASY",
         "sql": """
@@ -170,19 +139,6 @@ FROM `{catalog}`.`{schema}`.`mv_product_usage`
 WHERE `Usage Year` = 2025
 GROUP BY `Plan Tier`
 ORDER BY `avg_seat_utilization_pct` DESC, `plan_tier`
-""",
-    },
-    {
-        "question": "How many accounts are in each region and industry?",
-        "difficulty": "EASY",
-        "sql": """
-SELECT
-  `region`,
-  `industry`,
-  COUNT(*) AS `account_count`
-FROM `{catalog}`.`{schema}`.`accounts`
-GROUP BY `region`, `industry`
-ORDER BY `region`, `account_count` DESC, `industry`
 """,
     },
     {
@@ -498,6 +454,24 @@ FROM `{catalog}`.`{schema}`.`product_usage`
 WHERE `usage_year` = 2025
 GROUP BY `usage_month`, `segment`
 ORDER BY `usage_month`, `segment`
+""",
+    },
+    {
+        "question": "Which regions generate the most active ARR, and what share comes from AI feature adopters?",
+        "difficulty": "MEDIUM",
+        "sql": """
+SELECT
+  a.`region`,
+  COUNT(*) AS `active_subscription_count`,
+  ROUND(SUM(s.`annual_recurring_revenue_usd`), 2) AS `active_arr_usd`,
+  ROUND(SUM(CASE WHEN a.`ai_feature_adopter` THEN s.`annual_recurring_revenue_usd` ELSE 0 END), 2) AS `ai_adopter_arr_usd`,
+  ROUND(SUM(CASE WHEN a.`ai_feature_adopter` THEN s.`annual_recurring_revenue_usd` ELSE 0 END) * 100.0 / SUM(s.`annual_recurring_revenue_usd`), 2) AS `ai_adopter_arr_share_pct`
+FROM `{catalog}`.`{schema}`.`subscriptions` s
+JOIN `{catalog}`.`{schema}`.`accounts` a
+  ON s.`account_id` = a.`account_id`
+WHERE s.`subscription_status` = 'Active'
+GROUP BY a.`region`
+ORDER BY `active_arr_usd` DESC
 """,
     },
     {
@@ -859,6 +833,106 @@ WHERE `ai_adopter_churn_rate_pct` IS NOT NULL
 ORDER BY `non_adopter_minus_adopter_churn_gap_pct_points` DESC, `industry`
 """,
     },
+    {
+        "question": "What is the 2025 annualized logo churn rate by segment, measured against the average monthly active subscription base?",
+        "difficulty": "HARD",
+        "sql": """
+WITH months AS (
+  SELECT DISTINCT
+    `usage_month` AS `month_start`
+  FROM `{catalog}`.`{schema}`.`product_usage`
+  WHERE `usage_year` = 2025
+),
+monthly_active AS (
+  SELECT
+    m.`month_start`,
+    a.`segment`,
+    COUNT(*) AS `active_subscription_count`
+  FROM months m
+  JOIN `{catalog}`.`{schema}`.`subscriptions` s
+    ON s.`start_date` <= LAST_DAY(m.`month_start`)
+   AND (s.`end_date` IS NULL OR s.`end_date` >= m.`month_start`)
+  JOIN `{catalog}`.`{schema}`.`accounts` a
+    ON s.`account_id` = a.`account_id`
+  GROUP BY m.`month_start`, a.`segment`
+),
+avg_base AS (
+  -- Average the per-month active counts; do NOT sum point-in-time levels across months.
+  SELECT
+    `segment`,
+    AVG(`active_subscription_count`) AS `avg_monthly_active_base`
+  FROM monthly_active
+  GROUP BY `segment`
+),
+churns AS (
+  SELECT
+    `segment`,
+    COUNT(*) AS `churned_subscription_count`
+  FROM `{catalog}`.`{schema}`.`churn_events`
+  WHERE `churn_year` = 2025
+  GROUP BY `segment`
+)
+SELECT
+  b.`segment`,
+  ROUND(b.`avg_monthly_active_base`, 1) AS `avg_monthly_active_base`,
+  COALESCE(c.`churned_subscription_count`, 0) AS `churned_subscriptions_2025`,
+  ROUND(COALESCE(c.`churned_subscription_count`, 0) * 100.0 / b.`avg_monthly_active_base`, 2) AS `annual_logo_churn_rate_pct`
+FROM avg_base b
+LEFT JOIN churns c
+  ON b.`segment` = c.`segment`
+ORDER BY `annual_logo_churn_rate_pct` DESC, b.`segment`
+""",
+    },
+    {
+        "question": "Within each segment, which active accounts have a latest health score below their segment's 25th-percentile health score?",
+        "difficulty": "HARD",
+        "sql": """
+WITH latest_month AS (
+  SELECT
+    `subscription_id`,
+    MAX(`usage_month`) AS `latest_usage_month`
+  FROM `{catalog}`.`{schema}`.`product_usage`
+  GROUP BY `subscription_id`
+),
+latest_health AS (
+  SELECT
+    a.`account_name`,
+    a.`segment`,
+    s.`subscription_id`,
+    s.`annual_recurring_revenue_usd`,
+    u.`health_score` AS `latest_health_score`,
+    u.`seat_utilization_pct` AS `latest_utilization_pct`
+  FROM `{catalog}`.`{schema}`.`product_usage` u
+  JOIN latest_month lm
+    ON u.`subscription_id` = lm.`subscription_id`
+   AND u.`usage_month` = lm.`latest_usage_month`
+  JOIN `{catalog}`.`{schema}`.`subscriptions` s
+    ON u.`subscription_id` = s.`subscription_id`
+  JOIN `{catalog}`.`{schema}`.`accounts` a
+    ON s.`account_id` = a.`account_id`
+  WHERE s.`subscription_status` = 'Active'
+),
+segment_threshold AS (
+  SELECT
+    `segment`,
+    PERCENTILE_APPROX(`latest_health_score`, 0.25) AS `segment_p25_health_score`
+  FROM latest_health
+  GROUP BY `segment`
+)
+SELECT
+  lh.`segment`,
+  lh.`account_name`,
+  ROUND(lh.`latest_health_score`, 2) AS `latest_health_score`,
+  ROUND(st.`segment_p25_health_score`, 2) AS `segment_p25_health_score`,
+  ROUND(lh.`latest_utilization_pct`, 2) AS `latest_utilization_pct`,
+  ROUND(lh.`annual_recurring_revenue_usd`, 2) AS `arr_usd`
+FROM latest_health lh
+JOIN segment_threshold st
+  ON lh.`segment` = st.`segment`
+WHERE lh.`latest_health_score` < st.`segment_p25_health_score`
+ORDER BY lh.`segment`, lh.`latest_health_score`, `arr_usd` DESC
+""",
+    },
 ]
 
 assert len(BENCHMARKS) == 30
@@ -866,68 +940,7 @@ assert len(BENCHMARKS) == 30
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 3. Validate Benchmark SQL
-
-# COMMAND ----------
-
-
-def render_sql(benchmark):
-    return benchmark["sql"].strip().format(catalog=catalog, schema=schema)
-
-
-if run_sql_validation:
-    print("Validating benchmark SQL with spark.sql...")
-    validation_results = []
-    validation_failures = []
-    for index, benchmark in enumerate(BENCHMARKS, start=1):
-        rendered_sql = render_sql(benchmark)
-        try:
-            result_df = spark.sql(rendered_sql)
-            sample_rows = [row.asDict(recursive=True) for row in result_df.limit(1).collect()]
-            row_count = result_df.count()
-            validation_results.append(
-                {
-                    "index": index,
-                    "difficulty": benchmark["difficulty"],
-                    "status": "PASS",
-                    "row_count": row_count,
-                    "sample": sample_rows[0] if sample_rows else None,
-                    "question": benchmark["question"],
-                }
-            )
-        except Exception as exc:
-            validation_failures.append((index, benchmark["question"], str(exc), rendered_sql))
-            validation_results.append(
-                {
-                    "index": index,
-                    "difficulty": benchmark["difficulty"],
-                    "status": "FAIL",
-                    "row_count": None,
-                    "sample": None,
-                    "question": benchmark["question"],
-                }
-            )
-
-    print("index | status | difficulty | row_count | question")
-    for result in validation_results:
-        print(
-            f"{result['index']:02d} | {result['status']} | {result['difficulty']} | "
-            f"{result['row_count']} | {result['question']}"
-        )
-
-    if validation_failures:
-        for index, question, error, sql in validation_failures:
-            print(f"\nFAILED {index:02d}: {question}\n{error}\n{sql}")
-        raise ValueError(f"{len(validation_failures)} benchmark SQL statements failed validation.")
-
-    print(f"Validated {len(validation_results)} benchmark SQL statements with 0 failures.")
-else:
-    print("Skipping SQL validation because run_sql_validation is false.")
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## 4. Fetch Genie Space
+# MAGIC ## 3. Fetch Genie Space
 
 # COMMAND ----------
 
@@ -950,11 +963,16 @@ print(f"Fetched Genie Space `{space_id}`.")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 5. Replace Benchmark Questions
+# MAGIC ## 4. Replace Benchmark Questions
 
 # COMMAND ----------
 
 import uuid
+
+
+def render_sql(benchmark):
+    return benchmark["sql"].strip().format(catalog=catalog, schema=schema)
+
 
 questions = []
 for benchmark in BENCHMARKS:
@@ -983,7 +1001,7 @@ print(f"Prepared {len(questions)} benchmark questions.")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 6. Patch Genie Space
+# MAGIC ## 5. Patch Genie Space
 
 # COMMAND ----------
 
@@ -999,7 +1017,7 @@ print(f"Patched Genie Space `{space_id}`.")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 7. Round-trip Verification
+# MAGIC ## 6. Round-trip Verification
 
 # COMMAND ----------
 
@@ -1026,57 +1044,3 @@ assert verify_serialized.get("version") == pre_version, "version changed during 
 print("Round-trip verification succeeded.")
 print("Benchmarks replaced: 30")
 print("Verified unchanged keys: data_sources, instructions, version")
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## 8. Optional Conversation Spot-check
-
-# COMMAND ----------
-
-import time
-
-
-def nested_get(source, path, default=None):
-    current = source
-    for key in path:
-        if not isinstance(current, dict):
-            return default
-        current = current.get(key)
-        if current is None:
-            return default
-    return current
-
-
-if run_conversation_check:
-    print("Running sampled Genie conversation spot-check for the first 3 questions...")
-    for benchmark in BENCHMARKS[:3]:
-        start_resp = w.api_client.do(
-            "POST",
-            f"/api/2.0/genie/spaces/{space_id}/start-conversation",
-            body={"content": benchmark["question"]},
-        )
-        conversation_id = start_resp.get("conversation_id") or nested_get(start_resp, ["conversation", "id"])
-        message_id = start_resp.get("message_id") or nested_get(start_resp, ["message", "id"])
-        message_resp = start_resp
-
-        if conversation_id and message_id:
-            for _ in range(30):
-                status = (
-                    message_resp.get("status")
-                    or nested_get(message_resp, ["message", "status"])
-                    or ""
-                ).upper()
-                if status in ("COMPLETED", "FAILED", "CANCELLED"):
-                    break
-                time.sleep(2)
-                message_resp = w.api_client.do(
-                    "GET",
-                    f"/api/2.0/genie/spaces/{space_id}/conversations/{conversation_id}/messages/{message_id}",
-                )
-
-        print("=" * 80)
-        print(benchmark["question"])
-        print(json.dumps(message_resp, indent=2, default=str)[:4000])
-else:
-    print("Skipping optional conversation check because run_conversation_check is false.")

--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/talent_advisory_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/talent_advisory_genie_benchmark_loader.py
@@ -9,15 +9,14 @@
 # MAGIC
 # MAGIC The 30 questions span workforce planning, the hiring funnel, retention &
 # MAGIC attrition, internal mobility, compensation, and succession - each paired with a
-# MAGIC correct Databricks SQL answer that has been validated live against
+# MAGIC ground-truth Databricks SQL answer written against
 # MAGIC `dhuang_catalog.talent_advisory`.
 # MAGIC
 # MAGIC ### What this notebook does
-# MAGIC 1. (optional) Validates all 30 ground-truth SQL statements live before touching the space.
-# MAGIC 2. `GET`s the Genie Space with its serialized config.
-# MAGIC 3. Replaces **only** `serialized_space["benchmarks"]["questions"]` with the 30 entries.
-# MAGIC 4. `PATCH`es the space back, echoing existing metadata.
-# MAGIC 5. Round-trip verifies the 30 benchmarks landed and that `data_sources`,
+# MAGIC 1. `GET`s the Genie Space with its serialized config.
+# MAGIC 2. Replaces **only** `serialized_space["benchmarks"]["questions"]` with the 30 entries.
+# MAGIC 3. `PATCH`es the space back, echoing existing metadata.
+# MAGIC 4. Round-trip verifies the 30 benchmarks landed and that `data_sources`,
 # MAGIC    `instructions`, and `version` are unchanged.
 # MAGIC
 # MAGIC > **Safety note:** This notebook mutates **ONLY** `benchmarks.questions`. It does
@@ -40,14 +39,10 @@
 dbutils.widgets.text("space_id", "", "Target Genie Space ID (required)")
 dbutils.widgets.text("catalog", "dhuang_catalog", "Unity Catalog name")
 dbutils.widgets.text("schema", "talent_advisory", "Schema / database name")
-dbutils.widgets.dropdown("run_sql_validation", "true", ["true", "false"], "Validate SQL live before loading")
-dbutils.widgets.dropdown("run_conversation_check", "false", ["true", "false"], "Sample Genie conversation check (optional)")
 
 space_id = dbutils.widgets.get("space_id").strip()
 catalog = dbutils.widgets.get("catalog").strip() or "dhuang_catalog"
 schema = dbutils.widgets.get("schema").strip() or "talent_advisory"
-run_sql_validation = dbutils.widgets.get("run_sql_validation").strip().lower() == "true"
-run_conversation_check = dbutils.widgets.get("run_conversation_check").strip().lower() == "true"
 
 if not space_id:
     raise ValueError("Widget 'space_id' is required - set it to the target Genie Space ID.")
@@ -62,8 +57,6 @@ w = WorkspaceClient()
 
 print(f"Target Genie Space : {space_id}")
 print(f"Data location      : {catalog}.{schema}")
-print(f"SQL validation     : {run_sql_validation}")
-print(f"Conversation check : {run_conversation_check}")
 
 # COMMAND ----------
 
@@ -71,23 +64,17 @@ print(f"Conversation check : {run_conversation_check}")
 # MAGIC ## 2. The 30 benchmark questions
 # MAGIC
 # MAGIC Each entry is `{"question", "difficulty", "sql"}`. The SQL uses `{catalog}` /
-# MAGIC `{schema}` Python format placeholders rendered at load time. Mix: 8 EASY /
-# MAGIC 14 MEDIUM / 8 HARD.
+# MAGIC `{schema}` Python format placeholders rendered at load time. Mix: 5 EASY /
+# MAGIC 15 MEDIUM / 10 HARD.
 
 # COMMAND ----------
 
 BENCHMARKS = [
-    # ---------------- EASY (8) ----------------
+    # ---------------- EASY (5) ----------------
     {"question": "How many active employees do we currently have?", "difficulty": "EASY",
      "sql": "SELECT COUNT(*) AS active_employees FROM `{catalog}`.`{schema}`.`employees` WHERE is_active = true"},
     {"question": "How many work locations do we have in each region?", "difficulty": "EASY",
      "sql": "SELECT region, COUNT(*) AS location_count FROM `{catalog}`.`{schema}`.`locations` GROUP BY region ORDER BY location_count DESC, region"},
-    {"question": "How many employees are in each job family?", "difficulty": "EASY",
-     "sql": "SELECT job_family, COUNT(*) AS employee_count FROM `{catalog}`.`{schema}`.`employees` GROUP BY job_family ORDER BY employee_count DESC"},
-    {"question": "How many hiring requisitions were opened in each year?", "difficulty": "EASY",
-     "sql": "SELECT opened_year, COUNT(*) AS requisitions FROM `{catalog}`.`{schema}`.`requisitions` GROUP BY opened_year ORDER BY opened_year"},
-    {"question": "What was the average performance rating in the 2025 review cycle?", "difficulty": "EASY",
-     "sql": "SELECT ROUND(AVG(performance_rating), 2) AS avg_performance_rating FROM `{catalog}`.`{schema}`.`performance_reviews` WHERE review_year = 2025"},
     {"question": "How many roles are flagged as critical roles?", "difficulty": "EASY",
      "sql": "SELECT COUNT(*) AS critical_roles FROM `{catalog}`.`{schema}`.`job_roles` WHERE is_critical_role = true"},
     {"question": "How many employees have left, broken down by termination type?", "difficulty": "EASY",
@@ -95,7 +82,7 @@ BENCHMARKS = [
     {"question": "How many learning activities are completed versus in progress or dropped?", "difficulty": "EASY",
      "sql": "SELECT completion_status, COUNT(*) AS activities FROM `{catalog}`.`{schema}`.`learning_activity` GROUP BY completion_status ORDER BY activities DESC"},
 
-    # ---------------- MEDIUM (14) ----------------
+    # ---------------- MEDIUM (15) ----------------
     {"question": "For filled requisitions, what is the average time to fill and the total offers and accepted offers by job family?", "difficulty": "MEDIUM",
      "sql": "SELECT job_family, COUNT(*) AS filled_requisitions, ROUND(AVG(time_to_fill_days), 1) AS avg_time_to_fill_days, SUM(offer_count) AS offers, SUM(accepted_offer_count) AS accepted_offers FROM `{catalog}`.`{schema}`.`mart_hiring_funnel` WHERE status = 'Filled' GROUP BY job_family ORDER BY avg_time_to_fill_days DESC"},
     {"question": "Which org units have the most open requisitions right now? Show the top 10 by org unit name.", "difficulty": "MEDIUM",
@@ -124,8 +111,10 @@ BENCHMARKS = [
      "sql": "SELECT e.job_family, SUM(CASE WHEN es.is_critical_gap THEN 1 ELSE 0 END) AS critical_gaps, COUNT(*) AS total_assessments FROM `{catalog}`.`{schema}`.`employee_skills` es JOIN `{catalog}`.`{schema}`.`employees` e ON es.employee_id = e.employee_id GROUP BY e.job_family ORDER BY critical_gaps DESC"},
     {"question": "What is the readiness-level breakdown of named successors in our succession plans?", "difficulty": "MEDIUM",
      "sql": "SELECT readiness_level, COUNT(*) AS succession_plans, ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER (), 1) AS pct_of_plans FROM `{catalog}`.`{schema}`.`succession_plans` GROUP BY readiness_level ORDER BY succession_plans DESC"},
+    {"question": "How many active employees and what is the average compa-ratio in each region?", "difficulty": "MEDIUM",
+     "sql": "SELECT l.region, COUNT(*) AS active_employees, ROUND(AVG(e.compa_ratio_profile), 3) AS avg_compa_ratio FROM `{catalog}`.`{schema}`.`employees` e JOIN `{catalog}`.`{schema}`.`locations` l ON e.location_id = l.location_id WHERE e.is_active = true GROUP BY l.region ORDER BY active_employees DESC, l.region"},
 
-    # ---------------- HARD (8) ----------------
+    # ---------------- HARD (10) ----------------
     {"question": "For each business unit, which job family carries the highest average retention risk in 2025?", "difficulty": "HARD",
      "sql": "WITH risk AS (SELECT o.business_unit, rr.job_family, ROUND(AVG(rr.risk_score), 1) AS avg_risk_score, COUNT(*) AS snapshots FROM `{catalog}`.`{schema}`.`retention_risk_snapshots` rr JOIN `{catalog}`.`{schema}`.`org_units` o ON rr.org_unit_id = o.org_unit_id WHERE rr.snapshot_year = 2025 GROUP BY o.business_unit, rr.job_family), ranked AS (SELECT *, ROW_NUMBER() OVER (PARTITION BY business_unit ORDER BY avg_risk_score DESC, job_family) AS rn FROM risk) SELECT business_unit, job_family, avg_risk_score, snapshots FROM ranked WHERE rn = 1 ORDER BY avg_risk_score DESC"},
     {"question": "How did the average engagement score for Sales East change year over year from 2023 to 2025?", "difficulty": "HARD",
@@ -142,6 +131,10 @@ BENCHMARKS = [
      "sql": "WITH comp AS (SELECT c.job_family, p.is_high_performer, c.compa_ratio FROM `{catalog}`.`{schema}`.`compensation_snapshots` c JOIN `{catalog}`.`{schema}`.`performance_reviews` p ON c.employee_id = p.employee_id AND c.snapshot_year = p.review_year WHERE c.snapshot_year = 2025) SELECT job_family, ROUND(AVG(CASE WHEN is_high_performer THEN compa_ratio END), 3) AS high_performer_avg_compa, ROUND(AVG(CASE WHEN NOT is_high_performer THEN compa_ratio END), 3) AS other_avg_compa, ROUND(AVG(CASE WHEN is_high_performer THEN compa_ratio END) - AVG(CASE WHEN NOT is_high_performer THEN compa_ratio END), 3) AS compa_gap FROM comp GROUP BY job_family HAVING COUNT(CASE WHEN is_high_performer THEN 1 END) > 0 ORDER BY compa_gap"},
     {"question": "Which org units had the biggest increase in high-risk employees from Q1 2024 to Q4 2024? Show the top 10.", "difficulty": "HARD",
      "sql": "WITH q AS (SELECT o.org_unit_name, rr.snapshot_quarter_label, SUM(CASE WHEN rr.risk_band = 'High' THEN 1 ELSE 0 END) AS high_risk FROM `{catalog}`.`{schema}`.`retention_risk_snapshots` rr JOIN `{catalog}`.`{schema}`.`org_units` o ON rr.org_unit_id = o.org_unit_id WHERE rr.snapshot_quarter_label IN ('2024-Q1', '2024-Q4') GROUP BY o.org_unit_name, rr.snapshot_quarter_label) SELECT org_unit_name, MAX(CASE WHEN snapshot_quarter_label = '2024-Q1' THEN high_risk END) AS high_risk_q1, MAX(CASE WHEN snapshot_quarter_label = '2024-Q4' THEN high_risk END) AS high_risk_q4, MAX(CASE WHEN snapshot_quarter_label = '2024-Q4' THEN high_risk END) - MAX(CASE WHEN snapshot_quarter_label = '2024-Q1' THEN high_risk END) AS change_in_high_risk FROM q GROUP BY org_unit_name ORDER BY change_in_high_risk DESC LIMIT 10"},
+    {"question": "What are the median and 90th-percentile accepted offer salaries by business unit for offers accepted in 2025?", "difficulty": "HARD",
+     "sql": "SELECT o.business_unit, COUNT(*) AS accepted_offers, ROUND(PERCENTILE(a.offer_salary_usd, 0.5), 0) AS median_offer_salary_usd, ROUND(PERCENTILE(a.offer_salary_usd, 0.9), 0) AS p90_offer_salary_usd FROM `{catalog}`.`{schema}`.`applications` a JOIN `{catalog}`.`{schema}`.`requisitions` r ON a.requisition_id = r.requisition_id JOIN `{catalog}`.`{schema}`.`org_units` o ON r.org_unit_id = o.org_unit_id WHERE a.offer_accepted = true AND a.offer_salary_usd IS NOT NULL AND YEAR(a.offer_date) = 2025 GROUP BY o.business_unit ORDER BY median_offer_salary_usd DESC"},
+    {"question": "For requisitions filled in 2025, what is each business unit's internal-fill rate, and how does it compare to the company-wide internal-fill rate?", "difficulty": "HARD",
+     "sql": "WITH bu AS (SELECT o.business_unit, COUNT(*) AS filled_requisitions, SUM(CASE WHEN r.is_internal_fill THEN 1 ELSE 0 END) AS internal_fills FROM `{catalog}`.`{schema}`.`requisitions` r JOIN `{catalog}`.`{schema}`.`org_units` o ON r.org_unit_id = o.org_unit_id WHERE r.status = 'Filled' AND r.opened_year = 2025 GROUP BY o.business_unit) SELECT business_unit, filled_requisitions, internal_fills, ROUND(internal_fills * 100.0 / NULLIF(filled_requisitions, 0), 1) AS internal_fill_rate_pct, ROUND(SUM(internal_fills) OVER () * 100.0 / NULLIF(SUM(filled_requisitions) OVER (), 0), 1) AS company_internal_fill_rate_pct FROM bu ORDER BY internal_fill_rate_pct DESC, business_unit"},
 ]
 
 assert len(BENCHMARKS) == 30, f"expected 30 benchmarks, found {len(BENCHMARKS)}"
@@ -153,50 +146,7 @@ print(f"Loaded {len(BENCHMARKS)} benchmark questions. Difficulty mix: {_mix}")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 3. Validate every SQL live (gated by `run_sql_validation`)
-# MAGIC
-# MAGIC Runs all 30 ground-truth queries against `{catalog}.{schema}` before mutating
-# MAGIC the space. If ANY query fails, the notebook raises and stops - we never push
-# MAGIC benchmarks whose answers don't execute.
-
-# COMMAND ----------
-
-if run_sql_validation:
-    results = []
-    failures = []
-    for i, b in enumerate(BENCHMARKS, 1):
-        rendered = b["sql"].format(catalog=catalog, schema=schema)
-        try:
-            row_count = spark.sql(rendered).count()
-            results.append((i, b["difficulty"], "PASS", row_count, ""))
-        except Exception as e:  # noqa: BLE001 - surface any analysis/runtime error
-            msg = str(e).splitlines()[0][:160] if str(e) else type(e).__name__
-            results.append((i, b["difficulty"], "FAIL", None, msg))
-            failures.append((i, b["question"], msg))
-
-    pass_df = spark.createDataFrame(
-        [(r[0], r[1], r[2], r[3], r[4]) for r in results],
-        "idx int, difficulty string, status string, row_count int, error string",
-    )
-    display(pass_df.orderBy("idx"))
-
-    n_pass = sum(1 for r in results if r[2] == "PASS")
-    print(f"\nSQL validation: {n_pass}/{len(BENCHMARKS)} passed.")
-    if failures:
-        for idx, q, msg in failures:
-            print(f"  [{idx:02d}] FAIL: {q}\n        {msg}")
-        raise RuntimeError(
-            f"{len(failures)} benchmark SQL statement(s) failed validation - aborting "
-            f"before mutating the Genie Space."
-        )
-    print("All 30 ground-truth SQL statements executed successfully.")
-else:
-    print("run_sql_validation=false - skipping live SQL validation.")
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## 4. Fetch the Genie Space (GET) and snapshot the pre-image
+# MAGIC ## 3. Fetch the Genie Space (GET) and snapshot the pre-image
 
 # COMMAND ----------
 
@@ -215,7 +165,7 @@ if "serialized_space" not in resp:
 # The serialized space is a JSON-encoded string -> parse to a dict.
 serialized = json.loads(resp["serialized_space"])
 
-# Pre-image snapshots for the post-PATCH verification in step 6. We deep-copy via a
+# Pre-image snapshots for the post-PATCH verification in step 5. We deep-copy via a
 # JSON round-trip so later mutation of `serialized` cannot alias these snapshots.
 pre_data_sources = json.loads(json.dumps(serialized.get("data_sources")))
 pre_instructions = json.loads(json.dumps(serialized.get("instructions")))
@@ -231,7 +181,7 @@ print(f"existing benchmarks: {pre_benchmark_count}")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 5. Mutate ONLY `benchmarks.questions`, then PATCH the space
+# MAGIC ## 4. Mutate ONLY `benchmarks.questions`, then PATCH the space
 # MAGIC
 # MAGIC We replace the benchmark question list and leave `config`, `data_sources`,
 # MAGIC `instructions`, and `version` untouched.
@@ -267,7 +217,7 @@ print(f"PATCH submitted: replaced benchmarks.questions with {len(questions)} ent
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 6. Round-trip verify
+# MAGIC ## 5. Round-trip verify
 # MAGIC
 # MAGIC Re-fetch the space and assert: exactly 30 benchmarks landed, their questions
 # MAGIC match what we sent, and `data_sources` / `instructions` / `version` are
@@ -307,53 +257,3 @@ print(f"  data_sources      : UNCHANGED")
 print(f"  instructions      : UNCHANGED")
 print(f"  version           : UNCHANGED ({post_version})")
 print(f"  Difficulty mix    : {_mix}")
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## 7. (Optional) Sample Genie conversation check
-# MAGIC
-# MAGIC Gated by `run_conversation_check` (default **false**). For a small sample of
-# MAGIC questions, exercises the Genie Conversation API and prints Genie's answer for
-# MAGIC manual spot-checking. This is best-effort and never fails the notebook.
-
-# COMMAND ----------
-
-if run_conversation_check:
-    import time
-
-    SAMPLE_SIZE = 3
-    sample = BENCHMARKS[:SAMPLE_SIZE]
-    for b in sample:
-        q = b["question"]
-        print("=" * 64)
-        print(f"Q: {q}")
-        try:
-            start = w.api_client.do(
-                "POST",
-                f"/api/2.0/genie/spaces/{space_id}/start-conversation",
-                body={"content": q},
-            )
-            conversation_id = (start.get("conversation") or {}).get("id") or start.get("conversation_id")
-            message_id = (start.get("message") or {}).get("id") or start.get("message_id")
-            status = None
-            message = {}
-            for _ in range(30):  # poll up to ~150s
-                message = w.api_client.do(
-                    "GET",
-                    f"/api/2.0/genie/spaces/{space_id}/conversations/{conversation_id}/messages/{message_id}",
-                )
-                status = message.get("status")
-                if status in ("COMPLETED", "FAILED", "CANCELLED", "QUERY_RESULT_EXPIRED"):
-                    break
-                time.sleep(5)
-            print(f"   status: {status}")
-            for attachment in (message.get("attachments") or []):
-                if attachment.get("text"):
-                    print(f"   text: {attachment['text'].get('content')}")
-                if attachment.get("query"):
-                    print(f"   query: {attachment['query'].get('query')}")
-        except Exception as e:  # noqa: BLE001 - optional check, never fail the run
-            print(f"   conversation check error (non-fatal): {e}")
-else:
-    print("run_conversation_check=false - skipping optional Genie conversation check.")

--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/wind_turbine_maintenance_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/wind_turbine_maintenance_genie_benchmark_loader.py
@@ -3,7 +3,14 @@
 # MAGIC %md
 # MAGIC # Wind Turbine Predictive Maintenance Genie Benchmark Loader
 # MAGIC
-# MAGIC Loads 30 validated benchmark questions into a target Genie Space for the wind turbine maintenance demo dataset.
+# MAGIC Loads 30 benchmark questions into a target Genie Space for the wind turbine
+# MAGIC maintenance demo dataset. This notebook:
+# MAGIC
+# MAGIC - Defines 30 benchmark questions (5 EASY / 15 MEDIUM / 10 HARD) as SQL.
+# MAGIC - Fetches the Genie Space and replaces ONLY `benchmarks.questions` in the
+# MAGIC   serialized configuration, then patches it back.
+# MAGIC - Round-trip verifies that the questions loaded and that `data_sources`,
+# MAGIC   `instructions`, and `version` are left unchanged.
 # MAGIC
 # MAGIC Safety note: this notebook mutates ONLY `benchmarks.questions` in the serialized Genie Space configuration.
 
@@ -20,7 +27,6 @@
 # COMMAND ----------
 
 import json
-import time
 from copy import deepcopy
 
 from databricks.sdk import WorkspaceClient
@@ -33,8 +39,6 @@ try:
     dbutils.widgets.text("space_id", "", "Target Genie Space ID")
     dbutils.widgets.text("catalog", DEFAULT_CATALOG, "Unity Catalog name")
     dbutils.widgets.text("schema", DEFAULT_SCHEMA, "Schema name")
-    dbutils.widgets.dropdown("run_sql_validation", "true", ["true", "false"], "Run SQL validation")
-    dbutils.widgets.dropdown("run_conversation_check", "false", ["false", "true"], "Run sampled conversation check")
 except Exception:
     pass
 
@@ -50,8 +54,6 @@ def get_widget(name, default):
 space_id = get_widget("space_id", "")
 catalog = get_widget("catalog", DEFAULT_CATALOG)
 schema = get_widget("schema", DEFAULT_SCHEMA)
-run_sql_validation = get_widget("run_sql_validation", "true").lower() == "true"
-run_conversation_check = get_widget("run_conversation_check", "false").lower() == "true"
 
 if not space_id:
     raise ValueError("Set the required 'space_id' widget before running this benchmark loader.")
@@ -105,18 +107,6 @@ GROUP BY `component_type`, `status`
 ORDER BY `component_type`, `status`""",
     },
     {
-        "question": "What were the average capacity factor and average power output by reading year?",
-        "difficulty": "EASY",
-        "sql": """SELECT
-  `reading_year`,
-  COUNT(*) AS `reading_count`,
-  ROUND(AVG(`capacity_factor_pct`), 2) AS `avg_capacity_factor_pct`,
-  ROUND(AVG(`power_output_kw`), 2) AS `avg_power_output_kw`
-FROM `{catalog}`.`{schema}`.`sensor_readings`
-GROUP BY `reading_year`
-ORDER BY `reading_year`""",
-    },
-    {
         "question": "How many maintenance events do we have by maintenance type, and what did they cost?",
         "difficulty": "EASY",
         "sql": """SELECT
@@ -129,18 +119,6 @@ GROUP BY `maintenance_type`
 ORDER BY `event_count` DESC, `maintenance_type`""",
     },
     {
-        "question": "How many failures occurred by severity, and what downtime and repair cost did each severity create?",
-        "difficulty": "EASY",
-        "sql": """SELECT
-  `severity`,
-  COUNT(*) AS `failure_count`,
-  ROUND(SUM(`downtime_hours`), 2) AS `total_downtime_hours`,
-  ROUND(SUM(`repair_cost_usd`), 2) AS `total_repair_cost_usd`
-FROM `{catalog}`.`{schema}`.`failure_events`
-GROUP BY `severity`
-ORDER BY `failure_count` DESC, `severity`""",
-    },
-    {
         "question": "Which regions have the highest average capacity factor in the turbine performance metric view?",
         "difficulty": "EASY",
         "sql": """SELECT
@@ -151,18 +129,6 @@ ORDER BY `failure_count` DESC, `severity`""",
 FROM `{catalog}`.`{schema}`.`mv_turbine_performance`
 GROUP BY `Region`
 ORDER BY `avg_capacity_factor_pct` DESC, `region`""",
-    },
-    {
-        "question": "What are the most common failure types and their average downtime?",
-        "difficulty": "EASY",
-        "sql": """SELECT
-  `failure_type`,
-  COUNT(*) AS `failure_count`,
-  ROUND(AVG(`downtime_hours`), 2) AS `avg_downtime_hours`,
-  ROUND(AVG(`repair_cost_usd`), 2) AS `avg_repair_cost_usd`
-FROM `{catalog}`.`{schema}`.`failure_events`
-GROUP BY `failure_type`
-ORDER BY `failure_count` DESC, `failure_type`""",
     },
     {
         "question": "Which wind farms have the most installed rated capacity, and how many turbines are operating, derated, or offline?",
@@ -406,6 +372,23 @@ WHERE m.`work_order_priority` = 'High'
 GROUP BY m.`technician_team`, wf.`region`
 ORDER BY `high_priority_events` DESC, `total_cost_usd` DESC, m.`technician_team`, wf.`region`
 LIMIT 15""",
+    },
+    {
+        "question": "On average, how old are components when they fail, by component type and manufacturer, and how does that compare to their expected service life?",
+        "difficulty": "MEDIUM",
+        "sql": """SELECT
+  c.`component_type`,
+  c.`manufacturer`,
+  COUNT(*) AS `failure_count`,
+  ROUND(AVG(DATEDIFF(f.`failure_date`, c.`install_date`) / 365.25), 2) AS `avg_age_years_at_failure`,
+  ROUND(AVG(c.`expected_life_years`), 1) AS `avg_expected_life_years`,
+  ROUND(AVG(f.`repair_cost_usd`), 2) AS `avg_repair_cost_usd`
+FROM `{catalog}`.`{schema}`.`failure_events` f
+JOIN `{catalog}`.`{schema}`.`components` c
+  ON f.`component_id` = c.`component_id`
+GROUP BY c.`component_type`, c.`manufacturer`
+HAVING COUNT(*) >= 5
+ORDER BY `avg_age_years_at_failure`, c.`component_type`, c.`manufacturer`""",
     },
     {
         "question": "How have monthly failure counts and downtime changed month over month?",
@@ -707,6 +690,79 @@ LEFT JOIN component_summary cs
 ORDER BY ss.`high_anomaly_readings` DESC, ss.`elevated_anomaly_readings` DESC, ss.`avg_anomaly_score` DESC, t.`turbine_id`
 LIMIT 10""",
     },
+    {
+        "question": "For turbines that have failed more than once, what is the mean time between failures in days, and which turbines have the shortest intervals?",
+        "difficulty": "HARD",
+        "sql": """WITH ordered_failures AS (
+  SELECT
+    `turbine_id`,
+    `failure_date`,
+    LAG(`failure_date`) OVER (PARTITION BY `turbine_id` ORDER BY `failure_date`) AS `prev_failure_date`
+  FROM `{catalog}`.`{schema}`.`failure_events`
+), failure_intervals AS (
+  SELECT
+    `turbine_id`,
+    DATEDIFF(`failure_date`, `prev_failure_date`) AS `days_between_failures`
+  FROM ordered_failures
+  WHERE `prev_failure_date` IS NOT NULL
+)
+SELECT
+  wf.`farm_name`,
+  t.`turbine_id`,
+  t.`turbine_model`,
+  COUNT(*) AS `failure_interval_count`,
+  ROUND(AVG(fi.`days_between_failures`), 1) AS `mean_days_between_failures`,
+  MIN(fi.`days_between_failures`) AS `min_days_between_failures`,
+  MAX(fi.`days_between_failures`) AS `max_days_between_failures`
+FROM failure_intervals fi
+JOIN `{catalog}`.`{schema}`.`turbines` t
+  ON fi.`turbine_id` = t.`turbine_id`
+JOIN `{catalog}`.`{schema}`.`wind_farms` wf
+  ON t.`farm_id` = wf.`farm_id`
+GROUP BY wf.`farm_name`, t.`turbine_id`, t.`turbine_model`
+ORDER BY `mean_days_between_failures` ASC, `failure_interval_count` DESC, t.`turbine_id`
+LIMIT 15""",
+    },
+    {
+        "question": "When turbines are grouped into quartiles by their 2025 average capacity factor, how do anomaly scores, failures, and downtime compare across quartiles?",
+        "difficulty": "HARD",
+        "sql": """WITH turbine_perf AS (
+  SELECT
+    sr.`turbine_id`,
+    AVG(sr.`capacity_factor_pct`) AS `avg_capacity_factor_pct`,
+    AVG(sr.`anomaly_score`) AS `avg_anomaly_score`
+  FROM `{catalog}`.`{schema}`.`sensor_readings` sr
+  WHERE sr.`reading_year` = 2025
+  GROUP BY sr.`turbine_id`
+), bucketed AS (
+  SELECT
+    `turbine_id`,
+    `avg_capacity_factor_pct`,
+    `avg_anomaly_score`,
+    NTILE(4) OVER (ORDER BY `avg_capacity_factor_pct` DESC) AS `capacity_factor_quartile`
+  FROM turbine_perf
+), turbine_failures AS (
+  SELECT
+    `turbine_id`,
+    COUNT(*) AS `failure_count`,
+    SUM(`downtime_hours`) AS `total_downtime_hours`
+  FROM `{catalog}`.`{schema}`.`failure_events`
+  GROUP BY `turbine_id`
+)
+SELECT
+  b.`capacity_factor_quartile`,
+  COUNT(*) AS `turbine_count`,
+  ROUND(AVG(b.`avg_capacity_factor_pct`), 2) AS `avg_capacity_factor_pct`,
+  ROUND(AVG(b.`avg_anomaly_score`), 2) AS `avg_anomaly_score`,
+  SUM(COALESCE(tf.`failure_count`, 0)) AS `total_failures`,
+  ROUND(SUM(COALESCE(tf.`total_downtime_hours`, 0.0)), 2) AS `total_downtime_hours`,
+  ROUND(1.0 * SUM(COALESCE(tf.`failure_count`, 0)) / COUNT(*), 2) AS `avg_failures_per_turbine`
+FROM bucketed b
+LEFT JOIN turbine_failures tf
+  ON b.`turbine_id` = tf.`turbine_id`
+GROUP BY b.`capacity_factor_quartile`
+ORDER BY b.`capacity_factor_quartile`""",
+    },
 ]
 
 assert len(BENCHMARKS) == 30, f"Expected 30 benchmarks, found {len(BENCHMARKS)}"
@@ -724,53 +780,7 @@ print(f"Loaded {len(BENCHMARKS)} benchmarks: {difficulty_counts}")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 3. Validate SQL
-
-# COMMAND ----------
-
-if run_sql_validation:
-    validation_rows = []
-    failures = []
-
-    for idx, benchmark in enumerate(BENCHMARKS, start=1):
-        rendered_sql = render_sql(benchmark)
-        try:
-            rows = spark.sql(rendered_sql).collect()
-            validation_rows.append(
-                {
-                    "idx": idx,
-                    "difficulty": benchmark["difficulty"],
-                    "status": "PASS",
-                    "row_count": len(rows),
-                    "question": benchmark["question"],
-                }
-            )
-        except Exception as exc:
-            message = str(exc)
-            validation_rows.append(
-                {
-                    "idx": idx,
-                    "difficulty": benchmark["difficulty"],
-                    "status": "FAIL",
-                    "row_count": None,
-                    "question": benchmark["question"],
-                }
-            )
-            failures.append({"idx": idx, "question": benchmark["question"], "error": message})
-
-    spark.createDataFrame(validation_rows).orderBy("idx").show(30, truncate=False)
-
-    if failures:
-        raise RuntimeError(f"SQL validation failed for {len(failures)} benchmark(s): {json.dumps(failures, indent=2)}")
-
-    print(f"Validated {len(validation_rows)} benchmark SQL statements with 0 errors.")
-else:
-    print("Skipping live SQL validation because run_sql_validation=false.")
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## 4. Fetch Genie Space
+# MAGIC ## 3. Fetch Genie Space
 
 # COMMAND ----------
 
@@ -791,7 +801,7 @@ print(f"Existing benchmark question count: {len(serialized.get('benchmarks', {})
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 5. Replace Benchmark Questions
+# MAGIC ## 4. Replace Benchmark Questions
 
 # COMMAND ----------
 
@@ -822,7 +832,7 @@ print(f"Prepared {len(questions)} benchmark questions for patch.")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 6. Patch Genie Space
+# MAGIC ## 5. Patch Genie Space
 
 # COMMAND ----------
 
@@ -837,7 +847,7 @@ print("Patched Genie Space benchmark questions.")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 7. Round-Trip Verification
+# MAGIC ## 6. Round-Trip Verification
 
 # COMMAND ----------
 
@@ -861,40 +871,3 @@ assert post_serialized.get("version") == pre_version, "version changed unexpecte
 print("Round-trip verification succeeded.")
 print(f"Benchmark questions loaded: {len(post_questions)}")
 print("Verified data_sources, instructions, and version are unchanged.")
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## 8. Optional Sample Conversation Check
-
-# COMMAND ----------
-
-if run_conversation_check:
-    sample = BENCHMARKS[:3]
-    for benchmark in sample:
-        start = w.api_client.do(
-            "POST",
-            f"/api/2.0/genie/spaces/{space_id}/start-conversation",
-            body={"content": benchmark["question"]},
-        )
-        conversation_id = start.get("conversation_id") or start.get("conversation", {}).get("id")
-        message_id = start.get("message_id") or start.get("message", {}).get("id")
-
-        if not conversation_id or not message_id:
-            print(json.dumps({"question": benchmark["question"], "start_response": start}, indent=2))
-            continue
-
-        message = None
-        for _ in range(30):
-            message = w.api_client.do(
-                "GET",
-                f"/api/2.0/genie/spaces/{space_id}/conversations/{conversation_id}/messages/{message_id}",
-            )
-            status = message.get("status")
-            if status in ("COMPLETED", "FAILED", "CANCELLED"):
-                break
-            time.sleep(2)
-
-        print(json.dumps({"question": benchmark["question"], "message": message}, indent=2))
-else:
-    print("Skipping sampled conversation check because run_conversation_check=false.")


### PR DESCRIPTION
## What & why

Follow-up to the merged benchmark-loader PR (#115). Two changes across all six Genie
benchmark loader notebooks, per request:

1. **Removed the two optional checks** — `run_sql_validation` and
   `run_conversation_check` widgets, their reads/prints, and the SQL-validation and
   conversation-spot-check cells. Each notebook is now purely: define 30 benchmarks →
   `GET` the space → mutate **only** `benchmarks.questions` → `PATCH` → round-trip
   verify. (Validation is done by running the benchmark in the Genie UI instead.)
2. **Rebalanced difficulty from 8 EASY / 14 MEDIUM / 8 HARD → 5 / 15 / 10** in every
   domain. Three former-EASY questions per notebook were genuinely deepened or replaced
   (not just relabeled) so the difficulty tags stay honest, keeping 30 questions total.

## Validation

Every notebook was verified before this PR:

| Domain | Live SQL (all 30 run on warehouse `78e36e2b033b2d06`, `dhuang_catalog`) | Difficulty mix | Independent cross-vendor review |
|---|---|---|---|
| banking  | 30/30 ✅ | 5/15/10 ✅ | PASS |
| hospital | 30/30 ✅ | 5/15/10 ✅ | PASS |
| retail   | 30/30 ✅ | 5/15/10 ✅ | PASS |
| saas     | 30/30 ✅ | 5/15/10 ✅ | PASS |
| talent   | 30/30 ✅ | 5/15/10 ✅ | PASS |
| wind     | 30/30 ✅ | 5/15/10 ✅ | PASS |

**180/180 SQLs execute cleanly.** Each notebook parses (`ast`), contains zero references
to the removed toggles, and preserves the `GET → mutate-only-benchmarks → PATCH → verify`
mechanism and the `{catalog}`/`{schema}` placeholders.

### Grain correctness on the new HARD questions
The new questions are mostly rate/ratio and period-over-period shapes — exactly where a
denominator-grain bug caught in the prior round lived (talent attrition was ~12× off from
summing monthly snapshots). Each new ratio was reviewed for correct grain:
- **talent** internal-fill rate divides annual *event counts* (base `requisitions`), not
  the monthly-snapshot mart; the prior Q18 attrition fix (`AVG(month_active_headcount)`)
  is preserved untouched.
- **saas** annualized logo churn rate divides by the **average** of per-month active
  counts (not a sum).
- **retail** inventory turnover divides COGS by the **average** of monthly inventory
  levels (not a sum of month-end snapshots).
- **banking** bank-wide complaint rate is `SUM(complaints)/SUM(requests)`, not an average
  of per-region rates.
- **wind** failure-rate-per-installed-component uses the installed base; the capacity-factor
  quartile average divides by per-turbine count.

## Notes
- Generated by polly's multi-agent flow: implemented by `claude_code`, each in its own
  worktree; live-SQL validated by the orchestrator; independently reviewed by a different
  vendor (`pi`). Not merged — for human review/merge.
