### PR TITLE
Genie benchmark loaders: hardcoded config variables instead of widgets

### DIFF
--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/banking_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/banking_genie_benchmark_loader.py
@@ -30,20 +30,20 @@
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 1. Configuration & widgets
+# MAGIC ## 1. Configuration
 
 # COMMAND ----------
 
-dbutils.widgets.text("space_id", "", "Genie Space ID (required)")
-dbutils.widgets.text("catalog", "dhuang_catalog", "Unity Catalog name")
-dbutils.widgets.text("schema", "horizon_bank", "Schema / database name")
-
-space_id = dbutils.widgets.get("space_id").strip()
-catalog = dbutils.widgets.get("catalog").strip() or "dhuang_catalog"
-schema = dbutils.widgets.get("schema").strip() or "horizon_bank"
+# ============================================================
+# CONFIGURATION — edit these three values, then Run All
+# ============================================================
+space_id = ""                # REQUIRED: target Genie Space ID (e.g. "01ef...")
+catalog  = "dhuang_catalog"  # Unity Catalog name
+schema   = "horizon_bank"  # Schema / database name
+# ============================================================
 
 if not space_id:
-    raise ValueError("space_id widget is required — set it to the target Genie Space ID.")
+    raise ValueError("space_id is required — set it at the top of this cell.")
 
 import json
 import uuid

--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/hospital_readmission_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/hospital_readmission_genie_benchmark_loader.py
@@ -27,23 +27,20 @@
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 1. Widgets & Configuration
+# MAGIC ## 1. Configuration
 
 # COMMAND ----------
 
-# =============================================================================
-# CONFIGURATION
-# =============================================================================
-dbutils.widgets.text("space_id", "", "Target Genie Space ID (required)")
-dbutils.widgets.text("catalog", "dhuang_catalog", "Unity Catalog name")
-dbutils.widgets.text("schema", "hospital_readmission", "Schema / database name")
-
-space_id = dbutils.widgets.get("space_id").strip()
-catalog = dbutils.widgets.get("catalog").strip()
-schema = dbutils.widgets.get("schema").strip()
+# ============================================================
+# CONFIGURATION — edit these three values, then Run All
+# ============================================================
+space_id = ""                # REQUIRED: target Genie Space ID (e.g. "01ef...")
+catalog  = "dhuang_catalog"  # Unity Catalog name
+schema   = "hospital_readmission"  # Schema / database name
+# ============================================================
 
 if not space_id:
-    raise ValueError("Widget 'space_id' is required (the target Genie Space ID).")
+    raise ValueError("space_id is required — set it at the top of this cell.")
 
 print(f"space_id : {space_id}")
 print(f"catalog  : {catalog}")
@@ -67,7 +64,7 @@ print("WorkspaceClient ready.")
 # MAGIC
 # MAGIC Each entry: a business question, a difficulty tag (`EASY` / `MEDIUM` / `HARD`),
 # MAGIC and the ground-truth Databricks SQL. Tables are referenced with `{catalog}` /
-# MAGIC `{schema}` Python format placeholders, rendered from the widgets at load time.
+# MAGIC `{schema}` Python format placeholders, rendered from the config variables at load time.
 # MAGIC
 # MAGIC Mix: 5 EASY / 15 MEDIUM / 10 HARD. Note: each encounter has at most one
 # MAGIC readmission row, so `COUNT(DISTINCT readmission_id) / COUNT(DISTINCT encounter_id)`

--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/retail_apparel_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/retail_apparel_genie_benchmark_loader.py
@@ -22,22 +22,22 @@
 
 # COMMAND ----------
 
+# ============================================================
+# CONFIGURATION — edit these three values, then Run All
+# ============================================================
+space_id = ""                # REQUIRED: target Genie Space ID (e.g. "01ef...")
+catalog  = "dhuang_catalog"  # Unity Catalog name
+schema   = "retail_apparel"  # Schema / database name
+# ============================================================
+
 import copy
 import json
 import uuid
 
 from databricks.sdk import WorkspaceClient
 
-dbutils.widgets.text("space_id", "", "Target Genie Space ID")
-dbutils.widgets.text("catalog", "dhuang_catalog", "Unity Catalog")
-dbutils.widgets.text("schema", "retail_apparel", "Schema")
-
-space_id = dbutils.widgets.get("space_id").strip()
-catalog = dbutils.widgets.get("catalog").strip() or "dhuang_catalog"
-schema = dbutils.widgets.get("schema").strip() or "retail_apparel"
-
 if not space_id:
-    raise ValueError("Widget 'space_id' is required.")
+    raise ValueError("space_id is required — set it at the top of this cell.")
 
 w = WorkspaceClient()
 

--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/saas_churn_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/saas_churn_genie_benchmark_loader.py
@@ -15,42 +15,22 @@
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 1. Widgets and Configuration
+# MAGIC ## 1. Configuration
 
 # COMMAND ----------
 
+# ============================================================
+# CONFIGURATION — edit these three values, then Run All
+# ============================================================
+space_id = ""                # REQUIRED: target Genie Space ID (e.g. "01ef...")
+catalog  = "dhuang_catalog"  # Unity Catalog name
+schema   = "saas_churn"  # Schema / database name
+# ============================================================
+
 from databricks.sdk import WorkspaceClient
 
-DEFAULT_CATALOG = "dhuang_catalog"
-DEFAULT_SCHEMA = "saas_churn"
-
-
-def create_text_widget(name, default, label):
-    try:
-        dbutils.widgets.text(name, default, label)
-    except Exception:
-        pass
-
-
-create_text_widget("space_id", "", "Target Genie Space ID")
-create_text_widget("catalog", DEFAULT_CATALOG, "Unity Catalog name")
-create_text_widget("schema", DEFAULT_SCHEMA, "Schema name")
-
-
-def widget_value(name, default=""):
-    try:
-        value = dbutils.widgets.get(name).strip()
-        return value if value else default
-    except Exception:
-        return default
-
-
-space_id = widget_value("space_id")
-catalog = widget_value("catalog", DEFAULT_CATALOG)
-schema = widget_value("schema", DEFAULT_SCHEMA)
-
 if not space_id:
-    raise ValueError("The space_id widget is required.")
+    raise ValueError("space_id is required — set it at the top of this cell.")
 
 w = WorkspaceClient()
 

--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/talent_advisory_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/talent_advisory_genie_benchmark_loader.py
@@ -32,20 +32,20 @@
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 1. Widgets & configuration
+# MAGIC ## 1. Configuration
 
 # COMMAND ----------
 
-dbutils.widgets.text("space_id", "", "Target Genie Space ID (required)")
-dbutils.widgets.text("catalog", "dhuang_catalog", "Unity Catalog name")
-dbutils.widgets.text("schema", "talent_advisory", "Schema / database name")
-
-space_id = dbutils.widgets.get("space_id").strip()
-catalog = dbutils.widgets.get("catalog").strip() or "dhuang_catalog"
-schema = dbutils.widgets.get("schema").strip() or "talent_advisory"
+# ============================================================
+# CONFIGURATION — edit these three values, then Run All
+# ============================================================
+space_id = ""                # REQUIRED: target Genie Space ID (e.g. "01ef...")
+catalog  = "dhuang_catalog"  # Unity Catalog name
+schema   = "talent_advisory"  # Schema / database name
+# ============================================================
 
 if not space_id:
-    raise ValueError("Widget 'space_id' is required - set it to the target Genie Space ID.")
+    raise ValueError("space_id is required — set it at the top of this cell.")
 
 import json
 import uuid

--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/wind_turbine_maintenance_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/wind_turbine_maintenance_genie_benchmark_loader.py
@@ -22,41 +22,25 @@
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 1. Widgets and Configuration
+# MAGIC ## 1. Configuration
 
 # COMMAND ----------
+
+# ============================================================
+# CONFIGURATION — edit these three values, then Run All
+# ============================================================
+space_id = ""                # REQUIRED: target Genie Space ID (e.g. "01ef...")
+catalog  = "dhuang_catalog"  # Unity Catalog name
+schema   = "wind_turbine_maintenance"  # Schema / database name
+# ============================================================
 
 import json
 from copy import deepcopy
 
 from databricks.sdk import WorkspaceClient
 
-
-DEFAULT_CATALOG = "dhuang_catalog"
-DEFAULT_SCHEMA = "wind_turbine_maintenance"
-
-try:
-    dbutils.widgets.text("space_id", "", "Target Genie Space ID")
-    dbutils.widgets.text("catalog", DEFAULT_CATALOG, "Unity Catalog name")
-    dbutils.widgets.text("schema", DEFAULT_SCHEMA, "Schema name")
-except Exception:
-    pass
-
-
-def get_widget(name, default):
-    try:
-        value = dbutils.widgets.get(name).strip()
-        return value or default
-    except Exception:
-        return default
-
-
-space_id = get_widget("space_id", "")
-catalog = get_widget("catalog", DEFAULT_CATALOG)
-schema = get_widget("schema", DEFAULT_SCHEMA)
-
 if not space_id:
-    raise ValueError("Set the required 'space_id' widget before running this benchmark loader.")
+    raise ValueError("space_id is required — set it at the top of this cell.")
 
 w = WorkspaceClient()
 


### PR DESCRIPTION
## What & why

The six Genie benchmark loader notebooks read `space_id` / `catalog` / `schema` from Databricks **widgets**, which forced a run → "space_id required" error → fill the widget → re-run loop. This replaces the widget machinery with three plain **hardcoded module-level variables** at the top of the Configuration cell — edit the values in place, then **Run All**.

## Change (identical across all 6 notebooks)

- Removed every `dbutils.widgets.text/get` call, the widget-only helper wrappers (`create_text_widget` / `widget_value` in saas, `get_widget` in wind), and their now-unused `DEFAULT_*` constants.
- Added at the top of the Configuration cell:
  ```python
  # ============================================================
  # CONFIGURATION — edit these three values, then Run All
  # ============================================================
  space_id = ""                # REQUIRED: target Genie Space ID
  catalog  = "dhuang_catalog"
  schema   = "<per-domain default>"
  # ============================================================
  ```
- Kept the `if not space_id: raise ValueError(...)` guard (message reworded, no longer references a widget), all imports, `w = WorkspaceClient()`, and the print summaries.
- Fixed "widgets" wording in section headers / prose.

Per-domain `schema` defaults: banking=`horizon_bank`, hospital=`hospital_readmission`, retail=`retail_apparel`, saas=`saas_churn`, talent=`talent_advisory`, wind=`wind_turbine_maintenance`.

## Not changed

**Zero changes** to the 30 benchmark questions, SQL, difficulty labels, or the `GET → mutate-only-benchmarks.questions → PATCH → verify` logic in any notebook. The `BENCHMARKS` data structure is byte-identical to `main` in all six files.

## Validation

- AST parse OK ×6; no `dbutils.widgets` / helper references remain; hardcoded vars present with the correct per-domain `schema` defaults; `BENCHMARKS` proven structurally identical to `main`.
- Independent cross-vendor review (different vendor from the implementer): **PASS** — verified widget removal, variable placement/defaults, the guard, import-ordering safety for the reordered files, and that `BENCHMARKS`/SQL/logic are untouched.

Diff: 6 files, net −39 lines. Based on `main`. **Not merged — yours to merge.**
