### PR TITLE
Fix: order-insensitive round-trip benchmark verification in Genie loaders

### DIFF
--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/banking_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/banking_genie_benchmark_loader.py
@@ -533,12 +533,16 @@ resp2 = w.api_client.do(
 serialized2 = json.loads(resp2["serialized_space"])
 
 post_questions = (serialized2.get("benchmarks") or {}).get("questions") or []
-post_texts = [q.get("question", [None])[0] for q in post_questions]
-expected_texts = [b["question"] for b in BENCHMARKS]
+post_texts = sorted(
+    (q["question"][0] if isinstance(q.get("question"), list) else q.get("question"))
+    for q in post_questions
+)
+expected_texts = sorted(b["question"] for b in BENCHMARKS)
 
 # (a) Exactly 30 benchmark questions landed.
 assert len(post_questions) == 30, f"Expected 30 questions, found {len(post_questions)}"
-# (b) The 30 questions match what we loaded, in order (idempotent replace).
+# (b) The 30 questions match what we loaded (order-independent: compare sorted
+#     lists so missing/extra/duplicate questions are still caught).
 assert post_texts == expected_texts, "Loaded benchmark questions do not match BENCHMARKS"
 # (c) Untouched sections are byte-for-byte unchanged vs the pre-image.
 assert serialized2.get("data_sources") == pre_data_sources, "data_sources changed!"

--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/retail_apparel_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/retail_apparel_genie_benchmark_loader.py
@@ -923,11 +923,16 @@ verify_resp = w.api_client.do(
 verify_serialized = json.loads(verify_resp["serialized_space"])
 
 actual_questions = verify_serialized.get("benchmarks", {}).get("questions", [])
-actual_question_text = [q["question"][0] for q in actual_questions]
-expected_question_text = [b["question"] for b in BENCHMARKS]
+# Compare sorted lists so the check is order-independent (the API does not
+# preserve submission order) while still catching missing/extra/duplicate questions.
+actual_question_text = sorted(
+    (q["question"][0] if isinstance(q.get("question"), list) else q.get("question"))
+    for q in actual_questions
+)
+expected_question_text = sorted(b["question"] for b in BENCHMARKS)
 
 assert len(actual_questions) == 30, f"Expected 30 benchmark questions, found {len(actual_questions)}"
-assert actual_question_text == expected_question_text, "Round-trip question text does not match BENCHMARKS."
+assert actual_question_text == expected_question_text, "Round-trip question text does not match BENCHMARKS (order-independent)."
 assert verify_serialized.get("data_sources") == pre_data_sources, "data_sources changed unexpectedly."
 assert verify_serialized.get("instructions") == pre_instructions, "instructions changed unexpectedly."
 assert verify_serialized.get("version") == pre_version, "version changed unexpectedly."

--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/saas_churn_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/saas_churn_genie_benchmark_loader.py
@@ -1009,14 +1009,16 @@ verify_resp = w.api_client.do(
 verify_serialized = json.loads(verify_resp["serialized_space"])
 verify_questions = verify_serialized.get("benchmarks", {}).get("questions", [])
 
-expected_question_text = [benchmark["question"] for benchmark in BENCHMARKS]
-actual_question_text = [
-    question.get("question", [None])[0]
+# Compare sorted lists so the check is order-independent (the API does not
+# preserve submission order) while still catching missing/extra/duplicate questions.
+expected_question_text = sorted(benchmark["question"] for benchmark in BENCHMARKS)
+actual_question_text = sorted(
+    (question["question"][0] if isinstance(question.get("question"), list) else question.get("question"))
     for question in verify_questions
-]
+)
 
 assert len(verify_questions) == 30, f"Expected 30 benchmark questions, found {len(verify_questions)}."
-assert actual_question_text == expected_question_text, "Round-trip benchmark questions do not match expected order/text."
+assert actual_question_text == expected_question_text, "Round-trip benchmark questions do not match expected text (order-independent)."
 assert verify_serialized.get("data_sources") == pre_data_sources, "data_sources changed during patch."
 assert verify_serialized.get("instructions") == pre_instructions, "instructions changed during patch."
 assert verify_serialized.get("version") == pre_version, "version changed during patch."

--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/talent_advisory_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/talent_advisory_genie_benchmark_loader.py
@@ -235,9 +235,13 @@ serialized2 = json.loads(resp2["serialized_space"])
 post_questions = (serialized2.get("benchmarks") or {}).get("questions") or []
 assert len(post_questions) == 30, f"expected 30 benchmark questions, found {len(post_questions)}"
 
-# The 30 questions must match what we authored, in order.
-expected_questions = [b["question"] for b in BENCHMARKS]
-actual_questions = [(q.get("question") or [None])[0] for q in post_questions]
+# The 30 questions must match what we authored (order-independent: compare
+# sorted lists so missing/extra/duplicate questions are still caught).
+expected_questions = sorted(b["question"] for b in BENCHMARKS)
+actual_questions = sorted(
+    (q["question"][0] if isinstance(q.get("question"), list) else q.get("question"))
+    for q in post_questions
+)
 assert actual_questions == expected_questions, "benchmark question text does not match what was sent"
 
 # data_sources / instructions / version must be UNCHANGED vs the pre-image.

--- a/aibi/genie-demo-data/industry_data_generators/benchmark-tests/wind_turbine_maintenance_genie_benchmark_loader.py
+++ b/aibi/genie-demo-data/industry_data_generators/benchmark-tests/wind_turbine_maintenance_genie_benchmark_loader.py
@@ -843,11 +843,16 @@ post_resp = w.api_client.do(
 post_serialized = json.loads(post_resp["serialized_space"])
 
 post_questions = post_serialized.get("benchmarks", {}).get("questions", [])
-expected_questions = [benchmark["question"] for benchmark in BENCHMARKS]
-actual_questions = [question["question"][0] for question in post_questions]
+# Compare sorted lists so the check is order-independent (the API does not
+# preserve submission order) while still catching missing/extra/duplicate questions.
+expected_questions = sorted(benchmark["question"] for benchmark in BENCHMARKS)
+actual_questions = sorted(
+    (question["question"][0] if isinstance(question.get("question"), list) else question.get("question"))
+    for question in post_questions
+)
 
 assert len(post_questions) == 30, f"Expected 30 benchmark questions, found {len(post_questions)}"
-assert actual_questions == expected_questions, "Round-trip benchmark questions do not match expected questions."
+assert actual_questions == expected_questions, "Round-trip benchmark questions do not match expected questions (order-independent)."
 assert post_serialized.get("data_sources") == pre_data_sources, "data_sources changed unexpectedly."
 assert post_serialized.get("instructions") == pre_instructions, "instructions changed unexpectedly."
 assert post_serialized.get("version") == pre_version, "version changed unexpectedly."


### PR DESCRIPTION
## Summary
Fixes a spurious failure in the round-trip verification cell of the Genie benchmark loader notebooks:

```
assert post_texts == expected_texts, "Loaded benchmark questions do not match BENCHMARKS"
```

The Genie Spaces API does **not** guarantee it returns `benchmarks.questions` in the order they were submitted, so the original **element-wise, in-order** comparison of question texts against `BENCHMARKS` failed even when all 30 questions were present and correct — only the ordering differed.

## Fix
Make the question-text comparison **order-insensitive** by sorting **both** the expected and actual text lists before the `==` assert — using `sorted(...)` (preserves multiplicity), **not** `set(...)` (which would silently hide a duplicate/missing pair). This copies the pattern `hospital_readmission_genie_benchmark_loader.py` already used correctly.

Affected (5): `banking`, `retail_apparel`, `saas_churn`, `talent_advisory`, `wind_turbine_maintenance` loaders.
`hospital_readmission` was already correct and is **left untouched**.

## Scope / safety
- **No SQL, question text, or difficulty changes** — the `BENCHMARKS` data structure is byte-for-byte identical to `main` in all six notebooks (verified by AST-dump comparison).
- Only the verification comparison + its comment/assert wording (the stale "in order" claim) changed. The `len(...) == 30` count check and the `data_sources` / `instructions` / `version` asserts are unchanged.
- Still catches genuinely missing / extra / duplicate questions.

## Verification
- AST parse OK for all six notebooks; diff confined to the verify cell in 5 files (`+37 / -17`).
- Independent cross-vendor review (different vendor from the implementer): **PASS** — confirmed `sorted` (not `set`), scope safety, and no false-PASS regressions.

Loaders were not executed against Databricks in this PR (no SQL changed); validate by running the loader and the Genie benchmark in the UI as usual.
